### PR TITLE
refactor: improve Countdown API and simplify internals

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,9 +1,10 @@
 import eslint from '@eslint/js';
+import { defineConfig } from 'eslint/config';
 import tseslint from 'typescript-eslint';
 
-export default tseslint.config(
+export default defineConfig(
   eslint.configs.recommended,
-  ...tseslint.configs.recommended,
+  tseslint.configs.recommended,
   {
     files: ['**/*.ts'],
     rules: {
@@ -11,23 +12,15 @@ export default tseslint.config(
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/no-inferrable-types': 'off',
-      '@typescript-eslint/semi': ['error', 'always']
-    }
+    },
   },
   {
     files: ['**/*.test.ts', '**/__tests__/**/*.ts'],
     rules: {
-      '@typescript-eslint/no-explicit-any': 'off'
-    }
+      '@typescript-eslint/no-explicit-any': 'off',
+    },
   },
   {
-    ignores: [
-      'dist/',
-      '**/dist/**',
-      'node_modules/',
-      '*.js',
-      '*.mjs',
-      '*.cjs'
-    ]
+    ignores: ['dist/', '**/dist/**', 'node_modules/', '*.js', '*.mjs', '*.cjs'],
   }
 );

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -32,15 +32,20 @@ Supported runtimes:
 
 ```ts
 import { Countdown, TimerState } from '@timekeeper-countdown/core';
+import { formatTime } from '@timekeeper-countdown/core/format';
 
 const countdown = Countdown(300, {
-  onUpdate: (minutes, seconds) => {
+  onSnapshot: snapshot => {
+    const { minutes, seconds } = formatTime(snapshot);
     timerElement.textContent = `${minutes}:${seconds}`;
   },
   onStateChange: state => {
     if (state === TimerState.STOPPED) {
       console.log('Finished!');
     }
+  },
+  onError: error => {
+    console.error('Countdown error:', error);
   },
 });
 

--- a/packages/core/src/__tests__/countdown.test.ts
+++ b/packages/core/src/__tests__/countdown.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Mock } from 'vitest';
-import { Countdown, TimerState, type CountdownInstance } from '../api/countdown';
-import { type StateMachineModule } from '../state/state-machine';
+import { Countdown, TimerState } from '../api/countdown';
 
 const mockedNow = vi.hoisted(() => vi.fn<[], number>(() => Date.now())) as Mock<[], number>;
 
@@ -50,9 +49,9 @@ describe('Countdown - Happy Path', () => {
     });
 
     it('should create a countdown with options', () => {
-      const onUpdate = vi.fn();
+      const onSnapshot = vi.fn();
       const onStateChange = vi.fn();
-      const countdown = Countdown(60, { onUpdate, onStateChange });
+      const countdown = Countdown(60, { onSnapshot, onStateChange });
       expect(countdown).toBeDefined();
     });
   });
@@ -69,25 +68,25 @@ describe('Countdown - Happy Path', () => {
     });
 
     it('should update time as countdown progresses', () => {
-      const onUpdate = vi.fn();
-      const countdown = Countdown(65, { onUpdate });
+      const onSnapshot = vi.fn();
+      const countdown = Countdown(65, { onSnapshot });
 
       countdown.start();
 
       // Initial call
-      expect(onUpdate).toHaveBeenCalledWith('01', '05');
+      expect(onSnapshot).toHaveBeenCalledWith(expect.objectContaining({ totalSeconds: 65 }));
 
       // Clear previous calls
-      onUpdate.mockClear();
+      onSnapshot.mockClear();
 
       // Advance 1 second - timer checks every 100ms, so we need to advance past 1000ms
       vi.advanceTimersByTime(1100);
-      expect(onUpdate).toHaveBeenCalledWith('01', '04');
+      expect(onSnapshot).toHaveBeenCalledWith(expect.objectContaining({ totalSeconds: 64 }));
 
       // Clear and advance 5 more seconds
-      onUpdate.mockClear();
+      onSnapshot.mockClear();
       vi.advanceTimersByTime(5000);
-      expect(onUpdate).toHaveBeenCalledWith('00', '59');
+      expect(onSnapshot).toHaveBeenCalledWith(expect.objectContaining({ totalSeconds: 59 }));
     });
   });
 
@@ -104,12 +103,12 @@ describe('Countdown - Happy Path', () => {
     });
 
     it('should resume the countdown after pause', () => {
-      const onUpdate = vi.fn();
+      const onSnapshot = vi.fn();
       const onStateChange = vi.fn();
-      const countdown = Countdown(60, { onUpdate, onStateChange });
+      const countdown = Countdown(60, { onSnapshot, onStateChange });
 
       countdown.start();
-      expect(onUpdate).toHaveBeenCalledWith('01', '00');
+      expect(onSnapshot).toHaveBeenCalledWith(expect.objectContaining({ totalSeconds: 60 }));
 
       // Advance 5 seconds
       vi.advanceTimersByTime(5100);
@@ -130,16 +129,16 @@ describe('Countdown - Happy Path', () => {
       expect(onStateChange).toHaveBeenCalledWith(TimerState.RUNNING);
 
       // Clear previous calls and advance 1 second after resume
-      onUpdate.mockClear();
+      onSnapshot.mockClear();
       vi.advanceTimersByTime(1100);
-      expect(onUpdate).toHaveBeenCalledWith('00', '54');
+      expect(onSnapshot).toHaveBeenCalledWith(expect.objectContaining({ totalSeconds: 54 }));
     });
   });
 
   describe('Reset functionality', () => {
     it('should reset the countdown to initial value', () => {
-      const onUpdate = vi.fn();
-      const countdown = Countdown(30, { onUpdate });
+      const onSnapshot = vi.fn();
+      const countdown = Countdown(30, { onSnapshot });
 
       countdown.start();
       vi.advanceTimersByTime(10100); // Advance 10 seconds
@@ -149,7 +148,7 @@ describe('Countdown - Happy Path', () => {
       expect(countdown.getMinutes()).toBe('00');
       expect(countdown.getSeconds()).toBe('30');
       expect(countdown.getCurrentState()).toBe(TimerState.IDLE);
-      expect(onUpdate).toHaveBeenLastCalledWith('00', '30');
+      expect(onSnapshot).toHaveBeenLastCalledWith(expect.objectContaining({ totalSeconds: 30 }));
     });
 
     it('should allow starting after reset', () => {
@@ -166,8 +165,8 @@ describe('Countdown - Happy Path', () => {
 
   describe('Stop functionality', () => {
     it('should stop the countdown and reset to 0', () => {
-      const onUpdate = vi.fn();
-      const countdown = Countdown(45, { onUpdate });
+      const onSnapshot = vi.fn();
+      const countdown = Countdown(45, { onSnapshot });
 
       countdown.start();
       vi.advanceTimersByTime(15100); // Advance 15 seconds
@@ -177,7 +176,7 @@ describe('Countdown - Happy Path', () => {
       expect(countdown.getMinutes()).toBe('00');
       expect(countdown.getSeconds()).toBe('00');
       expect(countdown.getCurrentState()).toBe(TimerState.STOPPED);
-      expect(onUpdate).toHaveBeenLastCalledWith('00', '00');
+      expect(onSnapshot).toHaveBeenLastCalledWith(expect.objectContaining({ totalSeconds: 0 }));
     });
   });
 
@@ -231,9 +230,9 @@ describe('Countdown - Happy Path', () => {
 
   describe('Countdown completion', () => {
     it('should complete when reaching 0', () => {
-      const onUpdate = vi.fn();
+      const onSnapshot = vi.fn();
       const onStateChange = vi.fn();
-      const countdown = Countdown(3, { onUpdate, onStateChange });
+      const countdown = Countdown(3, { onSnapshot, onStateChange });
 
       countdown.start();
 
@@ -246,41 +245,41 @@ describe('Countdown - Happy Path', () => {
 
       // When timer completes, it should transition to STOPPED state first
       expect(countdown.getCurrentState()).toBe(TimerState.STOPPED);
-      expect(onUpdate).toHaveBeenCalledWith('00', '00');
+      expect(onSnapshot).toHaveBeenCalledWith(expect.objectContaining({ totalSeconds: 0 }));
     });
 
     it('should not continue counting after completion', () => {
-      const onUpdate = vi.fn();
-      const countdown = Countdown(2, { onUpdate });
+      const onSnapshot = vi.fn();
+      const countdown = Countdown(2, { onSnapshot });
 
       countdown.start();
       vi.advanceTimersByTime(2100); // Past completion
 
-      const callCount = onUpdate.mock.calls.length;
+      const callCount = onSnapshot.mock.calls.length;
 
       vi.advanceTimersByTime(1000); // Try to advance more
 
       // Should not have been called again
-      expect(onUpdate).toHaveBeenCalledTimes(callCount);
+      expect(onSnapshot).toHaveBeenCalledTimes(callCount);
     });
   });
 
   describe('Callbacks', () => {
-    it('should call onUpdate with formatted time on each tick', () => {
-      const onUpdate = vi.fn();
-      const countdown = Countdown(125, { onUpdate }); // 2:05
+    it('should call onSnapshot with snapshot on each tick', () => {
+      const onSnapshot = vi.fn();
+      const countdown = Countdown(125, { onSnapshot }); // 2:05
 
       countdown.start();
 
-      expect(onUpdate).toHaveBeenCalledWith('02', '05');
+      expect(onSnapshot).toHaveBeenCalledWith(expect.objectContaining({ totalSeconds: 125 }));
 
-      onUpdate.mockClear();
+      onSnapshot.mockClear();
       vi.advanceTimersByTime(1100);
-      expect(onUpdate).toHaveBeenCalledWith('02', '04');
+      expect(onSnapshot).toHaveBeenCalledWith(expect.objectContaining({ totalSeconds: 124 }));
 
-      onUpdate.mockClear();
+      onSnapshot.mockClear();
       vi.advanceTimersByTime(1000);
-      expect(onUpdate).toHaveBeenCalledWith('02', '03');
+      expect(onSnapshot).toHaveBeenCalledWith(expect.objectContaining({ totalSeconds: 123 }));
     });
 
     it('should call onStateChange for all state transitions', () => {
@@ -306,25 +305,25 @@ describe('Countdown - Happy Path', () => {
 
   describe('Destroy functionality', () => {
     it('should destroy the countdown timer', () => {
-      const onUpdate = vi.fn();
-      const countdown = Countdown(60, { onUpdate });
+      const onSnapshot = vi.fn();
+      const countdown = Countdown(60, { onSnapshot });
 
       countdown.start();
-      expect(onUpdate).toHaveBeenCalledTimes(1); // Initial call
+      expect(onSnapshot).toHaveBeenCalledTimes(1); // Initial call
 
       countdown.destroy();
 
       // Should not update after destroy
       vi.advanceTimersByTime(1100);
-      expect(onUpdate).toHaveBeenCalledTimes(1); // Still only initial call
+      expect(onSnapshot).toHaveBeenCalledTimes(1); // Still only initial call
     });
   });
 
   describe('Multiple operations sequence', () => {
     it('should handle complex sequence of operations', () => {
-      const onUpdate = vi.fn();
+      const onSnapshot = vi.fn();
       const onStateChange = vi.fn();
-      const countdown = Countdown(100, { onUpdate, onStateChange });
+      const countdown = Countdown(100, { onSnapshot, onStateChange });
 
       // Start
       countdown.start();
@@ -368,9 +367,9 @@ describe('Countdown - Happy Path', () => {
 
   describe('Timer completion flow', () => {
     it('should handle timer completion correctly', () => {
-      const onUpdate = vi.fn();
+      const onSnapshot = vi.fn();
       const onStateChange = vi.fn();
-      const countdown = Countdown(2, { onUpdate, onStateChange });
+      const countdown = Countdown(2, { onSnapshot, onStateChange });
 
       countdown.start();
 
@@ -382,7 +381,62 @@ describe('Countdown - Happy Path', () => {
 
       // Timer should complete and transition to STOPPED
       expect(countdown.getCurrentState()).toBe(TimerState.STOPPED);
-      expect(onUpdate).toHaveBeenCalledWith('00', '00');
+      expect(onSnapshot).toHaveBeenCalledWith(expect.objectContaining({ totalSeconds: 0 }));
+    });
+  });
+
+  describe('Idempotency and post-destroy safety', () => {
+    it('should not throw on double start', () => {
+      const countdown = Countdown(60);
+      countdown.start();
+      expect(() => countdown.start()).not.toThrow();
+    });
+
+    it('should not throw on double pause', () => {
+      const countdown = Countdown(60);
+      countdown.start();
+      countdown.pause();
+      expect(() => countdown.pause()).not.toThrow();
+    });
+
+    it('should not throw on double stop', () => {
+      const countdown = Countdown(60);
+      countdown.start();
+      countdown.stop();
+      expect(() => countdown.stop()).not.toThrow();
+    });
+
+    it('should not throw when calling methods after destroy', () => {
+      const countdown = Countdown(60);
+      countdown.start();
+      countdown.destroy();
+
+      expect(() => countdown.start()).not.toThrow();
+      expect(() => countdown.pause()).not.toThrow();
+      expect(() => countdown.resume()).not.toThrow();
+      expect(() => countdown.stop()).not.toThrow();
+      expect(() => countdown.reset()).not.toThrow();
+    });
+
+    it('should return stable values from getters after destroy', () => {
+      const countdown = Countdown(65);
+      countdown.start();
+      countdown.destroy();
+
+      expect(() => countdown.getSeconds()).not.toThrow();
+      expect(() => countdown.getMinutes()).not.toThrow();
+      expect(() => countdown.getHours()).not.toThrow();
+      expect(() => countdown.getDays()).not.toThrow();
+      expect(() => countdown.getWeeks()).not.toThrow();
+      expect(() => countdown.getYears()).not.toThrow();
+      expect(() => countdown.getCurrentState()).not.toThrow();
+      expect(() => countdown.getSnapshot()).not.toThrow();
+    });
+
+    it('should not throw on double destroy', () => {
+      const countdown = Countdown(60);
+      countdown.destroy();
+      expect(() => countdown.destroy()).not.toThrow();
     });
   });
 
@@ -396,31 +450,31 @@ describe('Countdown - Happy Path', () => {
     });
 
     it('should handle time format correctly during countdown', () => {
-      const onUpdate = vi.fn();
-      const countdown = Countdown(61, { onUpdate }); // 1:01
+      const onSnapshot = vi.fn();
+      const countdown = Countdown(61, { onSnapshot }); // 1:01
 
       countdown.start();
-      expect(onUpdate).toHaveBeenCalledWith('01', '01');
+      expect(onSnapshot).toHaveBeenCalledWith(expect.objectContaining({ totalSeconds: 61 }));
 
-      onUpdate.mockClear();
+      onSnapshot.mockClear();
       vi.advanceTimersByTime(2100);
-      expect(onUpdate).toHaveBeenCalledWith('00', '59');
+      expect(onSnapshot).toHaveBeenCalledWith(expect.objectContaining({ totalSeconds: 59 }));
     });
 
     it('should handle timer precision with 100ms intervals', () => {
-      const onUpdate = vi.fn();
-      const countdown = Countdown(5, { onUpdate });
+      const onSnapshot = vi.fn();
+      const countdown = Countdown(5, { onSnapshot });
 
       countdown.start();
 
       // Advance by 950ms - should not trigger update yet
       vi.advanceTimersByTime(950);
-      expect(onUpdate).toHaveBeenCalledTimes(1); // Only initial call
+      expect(onSnapshot).toHaveBeenCalledTimes(1); // Only initial call
 
       // Advance by another 100ms to pass 1 second
       vi.advanceTimersByTime(100);
-      expect(onUpdate).toHaveBeenCalledTimes(2); // Now should have updated
-      expect(onUpdate).toHaveBeenLastCalledWith('00', '04');
+      expect(onSnapshot).toHaveBeenCalledTimes(2); // Now should have updated
+      expect(onSnapshot).toHaveBeenLastCalledWith(expect.objectContaining({ totalSeconds: 4 }));
     });
   });
 });
@@ -457,8 +511,10 @@ describe('Countdown - Error Handling', () => {
       expect(() => Countdown(Number.MAX_SAFE_INTEGER + 1)).toThrowError('initialSeconds exceeds maximum safe integer');
     });
 
-    it('should throw error when onUpdate is not a function', () => {
-      expect(() => Countdown(60, { onUpdate: 'not a function' as any })).toThrowError('onUpdate must be a function');
+    it('should throw error when onSnapshot is not a function', () => {
+      expect(() => Countdown(60, { onSnapshot: 'not a function' as any })).toThrowError(
+        'onSnapshot must be a function'
+      );
     });
 
     it('should throw error when onStateChange is not a function', () => {
@@ -466,31 +522,49 @@ describe('Countdown - Error Handling', () => {
         'onStateChange must be a function'
       );
     });
+
+    it('should throw error when onError is not a function', () => {
+      expect(() => Countdown(60, { onError: 'not a function' as any })).toThrowError(
+        'onError must be a function'
+      );
+    });
   });
 
   describe('Callback error handling', () => {
-    it('should handle error in onUpdate callback', () => {
-      const onUpdate = vi.fn(() => {
-        throw new Error('onUpdate error');
+    it('should handle error in onSnapshot callback', () => {
+      const onSnapshot = vi.fn(() => {
+        throw new Error('onSnapshot error');
       });
-      const countdown = Countdown(60, { onUpdate });
+      const countdown = Countdown(60, { onSnapshot });
 
-      // Start countdown to trigger onUpdate
+      // Start countdown to trigger onSnapshot
       countdown.start();
 
       // Should not throw, error should be caught internally
       expect(() => vi.advanceTimersByTime(1100)).not.toThrow();
     });
 
-    it('should handle non-Error thrown in onUpdate callback', () => {
-      const onUpdate = vi.fn(() => {
+    it('should handle non-Error thrown in onSnapshot callback', () => {
+      const onSnapshot = vi.fn(() => {
         throw 'string error';
       });
-      const countdown = Countdown(60, { onUpdate });
+      const countdown = Countdown(60, { onSnapshot });
 
       countdown.start();
 
       expect(() => vi.advanceTimersByTime(1100)).not.toThrow();
+    });
+
+    it('should handle onSnapshot callback errors', () => {
+      const onSnapshot = vi.fn(() => {
+        throw new Error('onSnapshot error');
+      });
+      const countdown = Countdown(60, { onSnapshot });
+
+      countdown.start();
+
+      expect(() => vi.advanceTimersByTime(1100)).not.toThrow();
+      expect(onSnapshot).toHaveBeenCalled();
     });
 
     it('should handle onStateChange callback errors', () => {
@@ -504,11 +578,73 @@ describe('Countdown - Error Handling', () => {
     });
   });
 
+  describe('onError callback', () => {
+    it('should call onError when onSnapshot throws', () => {
+      const onError = vi.fn();
+      const onSnapshot = vi.fn(() => { throw new Error('snapshot boom'); });
+      const countdown = Countdown(60, { onSnapshot, onError });
+
+      countdown.start();
+
+      expect(onError).toHaveBeenCalledWith(expect.any(Error));
+      expect(onError.mock.calls[0][0].message).toBe('snapshot boom');
+    });
+
+    it('should call onError when onStateChange throws', () => {
+      const onError = vi.fn();
+      const onStateChange = vi.fn(() => { throw new Error('state boom'); });
+      const countdown = Countdown(60, { onStateChange, onError });
+
+      countdown.start();
+
+      expect(onError).toHaveBeenCalledWith(expect.any(Error));
+      expect(onError.mock.calls[0][0].message).toBe('state boom');
+    });
+
+    it('should normalize non-Error throws to Error instances', () => {
+      const onError = vi.fn();
+      const onSnapshot = vi.fn(() => { throw 'raw string error'; });
+      const countdown = Countdown(60, { onSnapshot, onError });
+
+      countdown.start();
+
+      expect(onError).toHaveBeenCalledWith(expect.any(Error));
+      expect(onError.mock.calls[0][0].message).toBe('raw string error');
+    });
+
+    it('should normalize non-Error throws from onStateChange to Error instances', () => {
+      const onError = vi.fn();
+      const onStateChange = vi.fn(() => { throw 'raw string from state'; });
+      const countdown = Countdown(60, { onStateChange, onError });
+
+      countdown.start();
+
+      expect(onError).toHaveBeenCalledWith(expect.any(Error));
+      expect(onError.mock.calls[0][0].message).toBe('raw string from state');
+    });
+
+    it('should not throw when onError is not provided and callbacks throw', () => {
+      const onSnapshot = vi.fn(() => { throw new Error('no handler'); });
+      const countdown = Countdown(60, { onSnapshot });
+
+      countdown.start();
+      expect(() => vi.advanceTimersByTime(1100)).not.toThrow();
+    });
+
+    it('should not throw when onError itself throws', () => {
+      const onError = vi.fn(() => { throw new Error('handler also broken'); });
+      const onSnapshot = vi.fn(() => { throw new Error('snapshot error'); });
+      const countdown = Countdown(60, { onSnapshot, onError });
+
+      expect(() => countdown.start()).not.toThrow();
+    });
+  });
+
   describe('Timer error handling', () => {
-    it('should handle timer execution errors', async () => {
-      // Create a countdown that will trigger onError callback
+    it('should handle timer execution errors gracefully', async () => {
+      // Create a countdown and verify it starts without throwing
       const countdown = Countdown(60, {
-        onUpdate: () => {
+        onSnapshot: () => {
           // Force an error during the timer tick
           throw new Error('Update processing error');
         },
@@ -516,79 +652,63 @@ describe('Countdown - Error Handling', () => {
 
       countdown.start();
 
-      // This should trigger the error in onUpdate, which gets caught
+      // This should trigger the error in onSnapshot, which gets caught
       expect(() => vi.advanceTimersByTime(1100)).not.toThrow();
     });
   });
 
-  describe('Method error handling using mocks', () => {
-    it('should handle errors in timer methods', async () => {
-      // We'll test error handling by mocking the timer module
+  describe('Method propagation (no swallowing)', () => {
+    it('should propagate errors thrown by the engine start method', async () => {
       vi.doMock('../runtime/timer', () => ({
         Timer: vi.fn(() => ({
-          start: vi.fn(() => {
-            throw new Error('Timer start error');
-          }),
+          start: vi.fn(() => { throw new Error('Timer start error'); }),
           stop: vi.fn(),
           reset: vi.fn(),
           destroy: vi.fn(),
           getTotalSeconds: vi.fn(() => 60),
           setSeconds: vi.fn(),
+          setInitialValue: vi.fn(),
+          getInitialValue: vi.fn(() => 60),
+          isRunning: vi.fn(() => false),
         })),
       }));
 
-      // Re-import with mocked timer
       const { Countdown: MockedCountdown } = await import('../api/countdown');
       const countdown = MockedCountdown(60);
 
-      // Should handle start error
-      expect(() => countdown.start()).not.toThrow();
+      expect(() => countdown.start()).toThrow('Timer start error');
 
       vi.doUnmock('../runtime/timer');
     });
 
-    it('should handle errors in state machine methods', async () => {
-      // Mock the state machine module
-      vi.doMock('../state/state-machine', async importOriginal => {
-        const actual = await importOriginal<typeof import('../state/state-machine')>();
-        return {
-          ...actual,
-          StateMachine: vi.fn(() => ({
-            canStart: vi.fn(() => true),
-            canPause: vi.fn(() => {
-              throw new Error('Cannot pause');
-            }),
-            canResume: vi.fn(() => true),
-            start: vi.fn(),
-            pause: vi.fn(),
-            resume: vi.fn(),
-            stop: vi.fn(),
-            reset: vi.fn(),
-            complete: vi.fn(),
-            destroy: vi.fn(),
-            getCurrentState: vi.fn(() => actual.TimerState.IDLE),
-          })),
-        };
-      });
+    it('should propagate errors thrown by the engine reset method', async () => {
+      vi.doMock('../runtime/timer', () => ({
+        Timer: vi.fn(() => ({
+          start: vi.fn(() => true),
+          stop: vi.fn(),
+          reset: vi.fn(() => { throw new Error('Reset error'); }),
+          destroy: vi.fn(),
+          getTotalSeconds: vi.fn(() => 60),
+          setSeconds: vi.fn(),
+          setInitialValue: vi.fn(),
+          getInitialValue: vi.fn(() => 60),
+          isRunning: vi.fn(() => false),
+        })),
+      }));
 
-      // Re-import with mocked state machine
       const { Countdown: MockedCountdown } = await import('../api/countdown');
       const countdown = MockedCountdown(60);
 
-      // Should handle pause error
-      expect(() => countdown.pause()).not.toThrow();
+      expect(() => countdown.reset()).toThrow('Reset error');
 
-      vi.doUnmock('../state/state-machine');
+      vi.doUnmock('../runtime/timer');
     });
 
-    it('should handle errors in formatter methods', async () => {
-      // Mock the formatter module to throw errors
+    it('should propagate errors thrown by the formatter in getters', async () => {
       vi.doMock('../format/formatter', () => ({
         Formatter: vi.fn(() => ({
           formatTime: vi.fn(() => ({ minutes: '00', seconds: '00' })),
-          formatSeconds: vi.fn(() => {
-            throw new Error('Format seconds error');
-          }),
+          formatSeconds: vi.fn(() => { throw new Error('Format seconds error'); }),
           formatMinutes: vi.fn(() => '00'),
           formatHours: vi.fn(() => '00'),
           formatDays: vi.fn(() => '00'),
@@ -597,755 +717,82 @@ describe('Countdown - Error Handling', () => {
         })),
       }));
 
-      // Re-import with mocked formatter
       const { Countdown: MockedCountdown } = await import('../api/countdown');
       const countdown = MockedCountdown(60);
 
-      // Should return safe value when formatter throws
-      expect(countdown.getSeconds()).toBe('00');
+      expect(() => countdown.getSeconds()).toThrow('Format seconds error');
 
       vi.doUnmock('../format/formatter');
-    });
-
-    it('should handle errors in timer reset method', async () => {
-      // Mock timer with reset that throws
-      vi.doMock('../runtime/timer', () => ({
-        Timer: vi.fn(() => ({
-          start: vi.fn(() => true),
-          stop: vi.fn(),
-          reset: vi.fn(() => {
-            throw new Error('Reset error');
-          }),
-          destroy: vi.fn(),
-          getTotalSeconds: vi.fn(() => 60),
-          setSeconds: vi.fn(),
-        })),
-      }));
-
-      const { Countdown: MockedCountdown } = await import('../api/countdown');
-      const countdown = MockedCountdown(60);
-
-      // Should not throw
-      expect(() => countdown.reset()).not.toThrow();
-
-      vi.doUnmock('../runtime/timer');
-    });
-
-    it('should handle errors in timer stop method', async () => {
-      // Mock timer with stop that throws
-      vi.doMock('../runtime/timer', () => ({
-        Timer: vi.fn(() => ({
-          start: vi.fn(() => true),
-          stop: vi.fn(() => {
-            throw new Error('Stop error');
-          }),
-          reset: vi.fn(),
-          destroy: vi.fn(),
-          getTotalSeconds: vi.fn(() => 60),
-          setSeconds: vi.fn(),
-        })),
-      }));
-
-      const { Countdown: MockedCountdown } = await import('../api/countdown');
-      const countdown = MockedCountdown(60);
-
-      // Should not throw
-      expect(() => countdown.stop()).not.toThrow();
-
-      vi.doUnmock('../runtime/timer');
-    });
-
-    it('should handle errors in timer destroy method', async () => {
-      // Mock timer with destroy that throws
-      vi.doMock('../runtime/timer', () => ({
-        Timer: vi.fn(() => ({
-          start: vi.fn(() => true),
-          stop: vi.fn(),
-          reset: vi.fn(),
-          destroy: vi.fn(() => {
-            throw new Error('Destroy error');
-          }),
-          getTotalSeconds: vi.fn(() => 60),
-          setSeconds: vi.fn(),
-        })),
-      }));
-
-      const { Countdown: MockedCountdown } = await import('../api/countdown');
-      const countdown = MockedCountdown(60);
-
-      // Should not throw
-      expect(() => countdown.destroy()).not.toThrow();
-
-      vi.doUnmock('../runtime/timer');
-    });
-
-    it('should fall back to IDLE when snapshot state access throws', async () => {
-      vi.resetModules();
-
-      vi.doMock('../api/countdown-engine', () => {
-        let shouldThrow = false;
-
-        const parts = {
-          years: 0,
-          weeks: 0,
-          days: 0,
-          hours: 0,
-          minutes: 0,
-          seconds: 0,
-          totalDays: 0,
-          totalHours: 0,
-          totalMinutes: 0,
-        };
-
-        const safeSnapshot = {
-          initialSeconds: 10,
-          totalSeconds: 10,
-          parts,
-          state: TimerState.IDLE,
-          isRunning: false,
-          isCompleted: false,
-        };
-
-        const errorSnapshot = {
-          initialSeconds: 10,
-          totalSeconds: 9,
-          parts: { ...parts, seconds: 9 },
-          isRunning: true,
-          isCompleted: false,
-        } as any;
-
-        Object.defineProperty(errorSnapshot, 'state', {
-          get: () => {
-            if (shouldThrow) {
-              throw new Error('state access error');
-            }
-            return TimerState.RUNNING;
-          },
-        });
-
-        return {
-          CountdownEngine: vi.fn(() => ({
-            start: vi.fn(),
-            pause: vi.fn(),
-            resume: vi.fn(),
-            reset: vi.fn(),
-            stop: vi.fn(),
-            setSeconds: vi.fn(),
-            destroy: vi.fn(),
-            getSnapshot: vi.fn(() => safeSnapshot),
-            subscribe: vi.fn((listener: (snapshot: any) => void) => {
-              shouldThrow = false;
-              listener(errorSnapshot);
-              shouldThrow = true;
-              return { unsubscribe: vi.fn() };
-            }),
-          })),
-        };
-      });
-
-      const { Countdown: MockedCountdown } = await import('../api/countdown');
-      const countdown = MockedCountdown(10);
-
-      expect(countdown.getCurrentState()).toBe(TimerState.IDLE);
-
-      vi.doUnmock('../api/countdown-engine');
-    });
-  });
-
-  describe('Getter error handling', () => {
-    it('should return safe values when getters throw errors', async () => {
-      // Test each getter method with formatter errors
-      const getterTests = [
-        { method: 'getMinutes', formatMethod: 'formatMinutes' },
-        { method: 'getHours', formatMethod: 'formatHours' },
-        { method: 'getDays', formatMethod: 'formatDays' },
-        { method: 'getWeeks', formatMethod: 'formatWeeks' },
-        { method: 'getYears', formatMethod: 'formatYears' },
-      ];
-
-      for (const test of getterTests) {
-        // Mock formatter to throw on specific method
-        vi.doMock('../format/formatter', () => ({
-          Formatter: vi.fn(() => ({
-            formatTime: vi.fn(() => ({ minutes: '00', seconds: '00' })),
-            formatSeconds: vi.fn(() => '00'),
-            formatMinutes: vi.fn(() =>
-              test.formatMethod === 'formatMinutes'
-                ? (() => {
-                    throw new Error('Format error');
-                  })()
-                : '00'
-            ),
-            formatHours: vi.fn(() =>
-              test.formatMethod === 'formatHours'
-                ? (() => {
-                    throw new Error('Format error');
-                  })()
-                : '00'
-            ),
-            formatDays: vi.fn(() =>
-              test.formatMethod === 'formatDays'
-                ? (() => {
-                    throw new Error('Format error');
-                  })()
-                : '00'
-            ),
-            formatWeeks: vi.fn(() =>
-              test.formatMethod === 'formatWeeks'
-                ? (() => {
-                    throw new Error('Format error');
-                  })()
-                : '00'
-            ),
-            formatYears: vi.fn(() =>
-              test.formatMethod === 'formatYears'
-                ? (() => {
-                    throw new Error('Format error');
-                  })()
-                : '00'
-            ),
-          })),
-        }));
-
-        const { Countdown: MockedCountdown } = await import('../api/countdown');
-        const countdown = MockedCountdown(60);
-
-        // Should return safe value
-        expect((countdown as CountdownInstance)[test.method as keyof CountdownInstance]()).toBe('00');
-
-        vi.doUnmock('../format/formatter');
-        vi.resetModules();
-      }
-    });
-
-    it('should return safe value when getCurrentState throws', async () => {
-      // Import original to get TimerState
-      const original = await import('../state/state-machine');
-
-      // Mock state machine to throw on getCurrentState
-      vi.doMock('../state/state-machine', () => ({
-        ...original,
-        StateMachine: vi.fn(() => ({
-          canStart: vi.fn(() => true),
-          canPause: vi.fn(() => true),
-          canResume: vi.fn(() => true),
-          start: vi.fn(),
-          pause: vi.fn(),
-          resume: vi.fn(),
-          stop: vi.fn(),
-          reset: vi.fn(),
-          complete: vi.fn(),
-          destroy: vi.fn(),
-          getCurrentState: vi.fn(() => {
-            throw new Error('Get state error');
-          }),
-        })),
-      }));
-
-      const { Countdown: MockedCountdown } = await import('../api/countdown');
-      const countdown = MockedCountdown(60);
-
-      // Should return safe value
-      expect(countdown.getCurrentState()).toBe(TimerState.IDLE);
-
-      vi.doUnmock('../state/state-machine');
     });
   });
 
   describe('Edge case error handling', () => {
-    it('should handle invalid totalSeconds in updateUI', () => {
-      const onUpdate = vi.fn();
-      const countdown = Countdown(60, { onUpdate });
-
-      // The countdown already has defensive programming for invalid values
-      // The formatTime function will handle NaN, negative, and Infinity values
-      // by defaulting to 0, so onUpdate should always receive valid formatted values
+    it('should handle invalid totalSeconds defensively', () => {
+      const onSnapshot = vi.fn();
+      const countdown = Countdown(60, { onSnapshot });
 
       countdown.start();
-      expect(onUpdate).toHaveBeenCalledWith('01', '00');
-
-      // Even if timer internally had issues, the defensive checks ensure safe values
-    });
-
-    it('should handle cascade errors in reset method', async () => {
-      // Mock timer to throw on both reset and stop (fallback)
-      vi.doMock('../runtime/timer', () => ({
-        Timer: vi.fn(() => ({
-          start: vi.fn(() => true),
-          stop: vi.fn(() => {
-            throw new Error('Stop error');
-          }),
-          reset: vi.fn(() => {
-            throw new Error('Reset error');
-          }),
-          destroy: vi.fn(),
-          getTotalSeconds: vi.fn(() => 0),
-          setSeconds: vi.fn(),
-        })),
-      }));
-
-      const { Countdown: MockedCountdown } = await import('../api/countdown');
-      const countdown = MockedCountdown(60);
-
-      // Should not throw even with cascade errors
-      expect(() => countdown.reset()).not.toThrow();
-
-      vi.doUnmock('../runtime/timer');
-    });
-
-    it('should handle cascade errors in stop method', async () => {
-      // Mock multiple timer methods to throw
-      vi.doMock('../runtime/timer', () => ({
-        Timer: vi.fn(() => ({
-          start: vi.fn(() => true),
-          stop: vi.fn(() => {
-            throw new Error('Stop error');
-          }),
-          reset: vi.fn(),
-          destroy: vi.fn(),
-          getTotalSeconds: vi.fn(() => {
-            throw new Error('Get seconds error');
-          }),
-          setSeconds: vi.fn(),
-        })),
-      }));
-
-      const { Countdown: MockedCountdown } = await import('../api/countdown');
-      const countdown = MockedCountdown(60);
-
-      // Should not throw even with cascade errors
-      expect(() => countdown.stop()).not.toThrow();
-
-      vi.doUnmock('../runtime/timer');
-    });
-
-    it('should handle cascade errors in destroy method', async () => {
-      // Mock both destroy and stop (fallback) to throw
-      vi.doMock('../runtime/timer', () => ({
-        Timer: vi.fn(() => ({
-          start: vi.fn(() => true),
-          stop: vi.fn(() => {
-            throw new Error('Stop error');
-          }),
-          reset: vi.fn(),
-          destroy: vi.fn(() => {
-            throw new Error('Destroy error');
-          }),
-          getTotalSeconds: vi.fn(() => 60),
-          setSeconds: vi.fn(),
-        })),
-      }));
-
-      const { Countdown: MockedCountdown } = await import('../api/countdown');
-      const countdown = MockedCountdown(60);
-
-      // Should not throw even with cascade errors in cleanup
-      expect(() => countdown.destroy()).not.toThrow();
-
-      vi.doUnmock('../runtime/timer');
+      expect(onSnapshot).toHaveBeenCalledWith(expect.objectContaining({ totalSeconds: 60 }));
     });
 
     it('should handle defensive programming for invalid totalSeconds', () => {
-      const onUpdate = vi.fn();
-      const countdown = Countdown(60, { onUpdate });
+      const onSnapshot = vi.fn();
+      const countdown = Countdown(60, { onSnapshot });
 
-      // The updateUI function has defensive programming that ensures
-      // totalSeconds is always a valid number >= 0
-      // This is already covered by the internal validation
       countdown.start();
 
-      // Check that onUpdate always receives valid formatted values
-      expect(onUpdate).toHaveBeenCalledWith(expect.any(String), expect.any(String));
-      const [minutes, seconds] = onUpdate.mock.calls[0];
-      expect(minutes).toMatch(/^\d{2,}$/);
-      expect(seconds).toMatch(/^\d{2}$/);
+      expect(onSnapshot).toHaveBeenCalledWith(expect.objectContaining({ totalSeconds: expect.any(Number) }));
+      const snapshot = onSnapshot.mock.calls[0][0];
+      expect(snapshot.totalSeconds).toBeGreaterThanOrEqual(0);
     });
 
-    it('should handle timer onError callback by simulating timer error', () => {
-      // Create a countdown that will trigger error in timer through onUpdate callback
+    it('should handle timer onError callback gracefully', () => {
       const countdown = Countdown(60, {
-        onUpdate: () => {
-          // This error should be caught internally, but doesn't trigger timer onError
+        onSnapshot: () => {
           throw new Error('Update callback error');
         },
       });
 
       countdown.start();
 
-      // Advance time to trigger the onUpdate error
+      // Advance time to trigger the onSnapshot error
       expect(() => vi.advanceTimersByTime(1100)).not.toThrow();
     });
 
-    it('should handle timer onError callback with Error object', async () => {
-      // Mock the timer module to trigger onError callback with Error object
-      vi.doMock('../runtime/timer', () => ({
-        Timer: vi.fn((_, events) => {
-          const timerInstance = {
-            start: vi.fn(() => {
-              // Simulate timer error by calling onError callback
-              setTimeout(() => events.onError(new Error('Timer internal error')), 0);
-              return true;
-            }),
-            stop: vi.fn(),
-            reset: vi.fn(),
-            destroy: vi.fn(),
-            getTotalSeconds: vi.fn(() => 60),
-            setSeconds: vi.fn(),
-          };
-          return timerInstance;
-        }),
-      }));
-
-      // Re-import with mocked timer
-      const { Countdown: MockedCountdown } = await import('../api/countdown');
-      const countdown = MockedCountdown(60);
-
-      countdown.start();
-
-      // Allow async timer error to execute
-      await vi.runAllTimersAsync();
-
-      // Timer error should be handled without throwing
-      expect(() => countdown.getCurrentState()).not.toThrow();
-
-      vi.doUnmock('../runtime/timer');
-    });
-
-    it('should handle timer onError callback with non-Error object', async () => {
-      // Mock the timer module to trigger onError callback with non-Error object
-      vi.doMock('../runtime/timer', () => ({
-        Timer: vi.fn((_, events) => {
-          const timerInstance = {
-            start: vi.fn(() => {
-              // Simulate timer error with non-Error object
-              setTimeout(() => events.onError('String error instead of Error object'), 0);
-              return true;
-            }),
-            stop: vi.fn(),
-            reset: vi.fn(),
-            destroy: vi.fn(),
-            getTotalSeconds: vi.fn(() => 60),
-            setSeconds: vi.fn(),
-          };
-          return timerInstance;
-        }),
-      }));
-
-      // Re-import with mocked timer
-      const { Countdown: MockedCountdown } = await import('../api/countdown');
-      const countdown = MockedCountdown(60);
-
-      countdown.start();
-
-      // Allow async timer error to execute
-      await vi.runAllTimersAsync();
-
-      // Timer error should be handled without throwing
-      expect(() => countdown.getCurrentState()).not.toThrow();
-
-      vi.doUnmock('../runtime/timer');
-    });
-
-    it('should trigger state machine stop when timer onError occurs', async () => {
+    it('should transition to STOPPED when an internal timer error occurs', () => {
       const onStateChange = vi.fn();
-
-      // Mock the timer module to trigger onError callback
-      vi.doMock('../runtime/timer', () => ({
-        Timer: vi.fn((_, events) => {
-          const timerInstance = {
-            start: vi.fn(() => {
-              // Simulate timer error
-              setTimeout(() => events.onError(new Error('Critical timer error')), 0);
-              return true;
-            }),
-            stop: vi.fn(),
-            reset: vi.fn(),
-            destroy: vi.fn(),
-            getTotalSeconds: vi.fn(() => 60),
-            setSeconds: vi.fn(),
-          };
-          return timerInstance;
-        }),
-      }));
-
-      // Re-import with mocked timer
-      const { Countdown: MockedCountdown, TimerState } = await import('../api/countdown');
-      const countdown = MockedCountdown(60, { onStateChange });
+      const countdown = Countdown(5, { onStateChange });
 
       countdown.start();
       expect(onStateChange).toHaveBeenCalledWith(TimerState.RUNNING);
 
-      // Allow async timer error to execute
-      await vi.runAllTimersAsync();
+      // Advance past the end to trigger completion → STOPPED transition
+      vi.advanceTimersByTime(6000);
 
-      // Verify state machine was stopped due to timer error
       expect(countdown.getCurrentState()).toBe(TimerState.STOPPED);
       expect(onStateChange).toHaveBeenCalledWith(TimerState.STOPPED);
-
-      vi.doUnmock('../runtime/timer');
-    });
-
-    it('should handle non-Error exceptions in resume method', async () => {
-      // Mock state machine to throw a non-Error object
-      vi.doMock('../state/state-machine', async importOriginal => {
-        const actual = (await importOriginal()) as StateMachineModule;
-        return {
-          ...actual,
-          StateMachine: vi.fn(() => ({
-            canStart: vi.fn(() => true),
-            canPause: vi.fn(() => true),
-            canResume: vi.fn(() => {
-              // Throw a non-Error object to cover the String(error) branch
-              throw 'string error instead of Error object';
-            }),
-            start: vi.fn(),
-            pause: vi.fn(),
-            resume: vi.fn(),
-            stop: vi.fn(),
-            reset: vi.fn(),
-            complete: vi.fn(),
-            destroy: vi.fn(),
-            getCurrentState: vi.fn(() => actual.TimerState.PAUSED),
-          })),
-        };
-      });
-
-      const { Countdown: MockedCountdown } = await import('../api/countdown');
-      const countdown = MockedCountdown(60);
-
-      // Should not throw
-      expect(() => countdown.resume()).not.toThrow();
-
-      vi.doUnmock('../state/state-machine');
-    });
-
-    it('should handle non-Error exceptions in start method', async () => {
-      // Mock state machine to throw a non-Error object in canStart
-      vi.doMock('../state/state-machine', async importOriginal => {
-        const actual = (await importOriginal()) as StateMachineModule;
-        return {
-          ...actual,
-          StateMachine: vi.fn(() => ({
-            canStart: vi.fn(() => {
-              throw { message: 'object error', code: 123 };
-            }),
-            canPause: vi.fn(() => true),
-            canResume: vi.fn(() => true),
-            start: vi.fn(),
-            pause: vi.fn(),
-            resume: vi.fn(),
-            stop: vi.fn(),
-            reset: vi.fn(),
-            complete: vi.fn(),
-            destroy: vi.fn(),
-            getCurrentState: vi.fn(() => actual.TimerState.IDLE),
-          })),
-        };
-      });
-
-      const { Countdown: MockedCountdown } = await import('../api/countdown');
-      const countdown = MockedCountdown(60);
-
-      // Should not throw
-      expect(() => countdown.start()).not.toThrow();
-
-      vi.doUnmock('../state/state-machine');
-    });
-
-    it('should handle non-Error exceptions in pause method', async () => {
-      // Mock state machine to throw a non-Error object in canPause
-      vi.doMock('../state/state-machine', async importOriginal => {
-        const actual = (await importOriginal()) as StateMachineModule;
-        return {
-          ...actual,
-          StateMachine: vi.fn(() => ({
-            canStart: vi.fn(() => true),
-            canPause: vi.fn(() => {
-              throw null;
-            }),
-            canResume: vi.fn(() => true),
-            start: vi.fn(),
-            pause: vi.fn(),
-            resume: vi.fn(),
-            stop: vi.fn(),
-            reset: vi.fn(),
-            complete: vi.fn(),
-            destroy: vi.fn(),
-            getCurrentState: vi.fn(() => actual.TimerState.RUNNING),
-          })),
-        };
-      });
-
-      const { Countdown: MockedCountdown } = await import('../api/countdown');
-      const countdown = MockedCountdown(60);
-
-      // Should not throw
-      expect(() => countdown.pause()).not.toThrow();
-
-      vi.doUnmock('../state/state-machine');
-    });
-
-    it('should handle non-Error exceptions in reset method', async () => {
-      // Mock timer to throw a non-Error object in reset
-      vi.doMock('../runtime/timer', () => ({
-        Timer: vi.fn(() => ({
-          start: vi.fn(() => true),
-          stop: vi.fn(),
-          reset: vi.fn(() => {
-            throw 42; // number error
-          }),
-          destroy: vi.fn(),
-          getTotalSeconds: vi.fn(() => 60),
-          setSeconds: vi.fn(),
-        })),
-      }));
-
-      const { Countdown: MockedCountdown } = await import('../api/countdown');
-      const countdown = MockedCountdown(60);
-
-      // Should not throw
-      expect(() => countdown.reset()).not.toThrow();
-
-      vi.doUnmock('../runtime/timer');
-    });
-
-    it('should handle non-Error exceptions in stop method', async () => {
-      // Mock timer to throw a non-Error object in stop
-      vi.doMock('../runtime/timer', () => ({
-        Timer: vi.fn(() => ({
-          start: vi.fn(() => true),
-          stop: vi.fn(() => {
-            throw false; // boolean error
-          }),
-          reset: vi.fn(),
-          destroy: vi.fn(),
-          getTotalSeconds: vi.fn(() => 60),
-          setSeconds: vi.fn(),
-        })),
-      }));
-
-      const { Countdown: MockedCountdown } = await import('../api/countdown');
-      const countdown = MockedCountdown(60);
-
-      // Should not throw
-      expect(() => countdown.stop()).not.toThrow();
-
-      vi.doUnmock('../runtime/timer');
-    });
-
-    it('should handle non-Error exceptions in destroy method', async () => {
-      // Mock timer to throw a non-Error object in destroy
-      vi.doMock('../runtime/timer', () => ({
-        Timer: vi.fn(() => ({
-          start: vi.fn(() => true),
-          stop: vi.fn(),
-          reset: vi.fn(),
-          destroy: vi.fn(() => {
-            throw undefined; // undefined error
-          }),
-          getTotalSeconds: vi.fn(() => 60),
-          setSeconds: vi.fn(),
-        })),
-      }));
-
-      const { Countdown: MockedCountdown } = await import('../api/countdown');
-      const countdown = MockedCountdown(60);
-
-      // Should not throw
-      expect(() => countdown.destroy()).not.toThrow();
-
-      vi.doUnmock('../runtime/timer');
-    });
-
-    it('should handle non-Error exceptions in getter methods', async () => {
-      // Mock timer to throw a non-Error object in getTotalSeconds
-      vi.doMock('../runtime/timer', () => ({
-        Timer: vi.fn(() => ({
-          start: vi.fn(() => true),
-          stop: vi.fn(),
-          reset: vi.fn(),
-          destroy: vi.fn(),
-          getTotalSeconds: vi.fn(() => {
-            throw Symbol('symbol error');
-          }),
-          setSeconds: vi.fn(),
-        })),
-      }));
-
-      const { Countdown: MockedCountdown } = await import('../api/countdown');
-      const countdown = MockedCountdown(60);
-
-      // Test all getter methods - they should return safe values and not throw
-      expect(countdown.getSeconds()).toBe('00');
-      expect(countdown.getMinutes()).toBe('01');
-      expect(countdown.getHours()).toBe('00');
-      expect(countdown.getDays()).toBe('00');
-      expect(countdown.getWeeks()).toBe('00');
-      expect(countdown.getYears()).toBe('00');
-
-      vi.doUnmock('../runtime/timer');
-    });
-
-    it('should handle non-Error exceptions in getCurrentState method', async () => {
-      // Mock state machine to throw a non-Error object in getCurrentState
-      vi.doMock('../state/state-machine', async importOriginal => {
-        const actual = (await importOriginal()) as StateMachineModule;
-        return {
-          ...actual,
-          StateMachine: vi.fn(() => ({
-            canStart: vi.fn(() => true),
-            canPause: vi.fn(() => true),
-            canResume: vi.fn(() => true),
-            start: vi.fn(),
-            pause: vi.fn(),
-            resume: vi.fn(),
-            stop: vi.fn(),
-            reset: vi.fn(),
-            complete: vi.fn(),
-            destroy: vi.fn(),
-            getCurrentState: vi.fn(() => {
-              throw new Date(); // Date object error
-            }),
-          })),
-        };
-      });
-
-      const { Countdown: MockedCountdown, TimerState } = await import('../api/countdown');
-      const countdown = MockedCountdown(60);
-
-      // Should return safe value and not throw
-      expect(countdown.getCurrentState()).toBe(TimerState.IDLE);
-
-      vi.doUnmock('../state/state-machine');
     });
 
     it('should handle invalid totalSeconds in updateUI defensive check', () => {
-      const onUpdate = vi.fn();
-      const countdown = Countdown(60, { onUpdate });
+      const onSnapshot = vi.fn();
+      const countdown = Countdown(60, { onSnapshot });
 
-      // Access the internal updateUI function by triggering start
       countdown.start();
 
-      // The updateUI function has defensive checks for totalSeconds
-      // This test ensures the defensive programming works correctly
-      expect(onUpdate).toHaveBeenCalledWith('01', '00');
+      expect(onSnapshot).toHaveBeenCalledWith(expect.objectContaining({ totalSeconds: 60 }));
 
-      // Clear previous calls
-      onUpdate.mockClear();
+      onSnapshot.mockClear();
 
-      // Advance time to trigger updateUI again
       vi.advanceTimersByTime(1100);
-      expect(onUpdate).toHaveBeenCalled();
+      expect(onSnapshot).toHaveBeenCalled();
 
-      // Check that all calls have valid formatted strings
-      onUpdate.mock.calls.forEach(call => {
-        expect(call[0]).toMatch(/^\d{2,}$/); // minutes
-        expect(call[1]).toMatch(/^\d{2}$/); // seconds
+      onSnapshot.mock.calls.forEach(call => {
+        expect(call[0].totalSeconds).toBeGreaterThanOrEqual(0);
       });
     });
 
     it('should handle negative totalSeconds in updateUI defensive check', async () => {
-      const onUpdate = vi.fn();
+      const onSnapshot = vi.fn();
 
       // Mock timer to return negative totalSeconds to trigger the defensive check
       vi.doMock('../runtime/timer', () => ({
@@ -1360,18 +807,18 @@ describe('Countdown - Error Handling', () => {
       }));
 
       const { Countdown: MockedCountdown } = await import('../api/countdown');
-      const countdown = MockedCountdown(60, { onUpdate });
+      const countdown = MockedCountdown(60, { onSnapshot });
 
       countdown.start();
 
-      // Should use 0 instead of negative value due to defensive check
-      expect(onUpdate).toHaveBeenCalledWith('00', '00');
+      // The engine passes the raw timer value through; sanitization happens in the Formatter layer
+      expect(onSnapshot).toHaveBeenCalledWith(expect.objectContaining({ totalSeconds: -5 }));
 
       vi.doUnmock('../runtime/timer');
     });
 
     it('should handle NaN totalSeconds in updateUI defensive check', async () => {
-      const onUpdate = vi.fn();
+      const onSnapshot = vi.fn();
 
       // Mock timer to return NaN totalSeconds to trigger the defensive check
       vi.doMock('../runtime/timer', () => ({
@@ -1386,18 +833,18 @@ describe('Countdown - Error Handling', () => {
       }));
 
       const { Countdown: MockedCountdown } = await import('../api/countdown');
-      const countdown = MockedCountdown(60, { onUpdate });
+      const countdown = MockedCountdown(60, { onSnapshot });
 
       countdown.start();
 
-      // Should use 0 instead of NaN due to defensive check
-      expect(onUpdate).toHaveBeenCalledWith('00', '00');
+      // The engine passes the raw timer value through; sanitization happens in the Formatter layer
+      expect(onSnapshot).toHaveBeenCalledWith(expect.objectContaining({ totalSeconds: NaN }));
 
       vi.doUnmock('../runtime/timer');
     });
 
     it('should handle Infinity totalSeconds in updateUI defensive check', async () => {
-      const onUpdate = vi.fn();
+      const onSnapshot = vi.fn();
 
       // Mock timer to return Infinity totalSeconds to trigger the defensive check
       vi.doMock('../runtime/timer', () => ({
@@ -1412,61 +859,15 @@ describe('Countdown - Error Handling', () => {
       }));
 
       const { Countdown: MockedCountdown } = await import('../api/countdown');
-      const countdown = MockedCountdown(60, { onUpdate });
+      const countdown = MockedCountdown(60, { onSnapshot });
 
       countdown.start();
 
-      // Should use 0 instead of Infinity due to defensive check
-      expect(onUpdate).toHaveBeenCalledWith('00', '00');
+      // The engine passes the raw timer value through; sanitization happens in the Formatter layer
+      expect(onSnapshot).toHaveBeenCalledWith(expect.objectContaining({ totalSeconds: Infinity }));
 
       vi.doUnmock('../runtime/timer');
     });
 
-    it('should handle Error object in resume method catch block', async () => {
-      // Mock timer to succeed but state machine to throw Error
-      vi.doMock('../runtime/timer', () => ({
-        Timer: vi.fn(() => ({
-          start: vi.fn(() => true), // Return true so we enter the if block
-          stop: vi.fn(),
-          reset: vi.fn(),
-          destroy: vi.fn(),
-          getTotalSeconds: vi.fn(() => 60),
-          setSeconds: vi.fn(),
-        })),
-      }));
-
-      // Mock state machine to throw Error in resume method
-      vi.doMock('../state/state-machine', async importOriginal => {
-        const actual = (await importOriginal()) as StateMachineModule;
-        return {
-          ...actual,
-          StateMachine: vi.fn(() => ({
-            canStart: vi.fn(() => true),
-            canPause: vi.fn(() => true),
-            canResume: vi.fn(() => true), // Allow resume
-            start: vi.fn(),
-            pause: vi.fn(),
-            resume: vi.fn(() => {
-              // Throw Error to test line 131 - Error path
-              throw new Error('Resume state machine error');
-            }),
-            stop: vi.fn(),
-            reset: vi.fn(),
-            complete: vi.fn(),
-            destroy: vi.fn(),
-            getCurrentState: vi.fn(() => actual.TimerState.PAUSED),
-          })),
-        };
-      });
-
-      const { Countdown: MockedCountdown } = await import('../api/countdown');
-      const countdown = MockedCountdown(60);
-
-      // Should not throw and should handle the error
-      expect(() => countdown.resume()).not.toThrow();
-
-      vi.doUnmock('../runtime/timer');
-      vi.doUnmock('../state/state-machine');
-    });
   });
 });

--- a/packages/core/src/__tests__/formatter.test.ts
+++ b/packages/core/src/__tests__/formatter.test.ts
@@ -270,38 +270,6 @@ describe('Formatter', () => {
       expect(formatter.formatYears(hugeNumber)).toBeDefined();
     });
 
-    it('should test toString that throws error to cover catch block', () => {
-      // Para cobrir o catch block, precisamos fazer toString() lançar um erro
-      // Vamos usar um spy para modificar o comportamento do Math.floor temporariamente
-      const originalFloor = Math.floor;
-      const originalToString = Number.prototype.toString;
-
-      // Fazer toString lançar erro
-      Number.prototype.toString = function () {
-        if (this.valueOf() === 42) {
-          throw new Error('Force catch block');
-        }
-        return originalToString.call(this);
-      };
-
-      // Fazer Math.floor retornar nosso valor especial
-      Math.floor = function (value: number) {
-        if (value === 0.7) {
-          // valor especial que vamos usar
-          return 42;
-        }
-        return originalFloor(value);
-      };
-
-      // Testar - deve cair no catch e retornar '00'
-      const result = formatter.formatTime(0.7);
-      expect(result.seconds).toBe('00');
-
-      // Restaurar comportamento original
-      Math.floor = originalFloor;
-      Number.prototype.toString = originalToString;
-    });
-
     it('should cover the !Number.isFinite branch by manipulating Math.floor', () => {
       // Para testar !Number.isFinite(value) no safeFormat
       const originalFloor = Math.floor;

--- a/packages/core/src/__tests__/timer.test.ts
+++ b/packages/core/src/__tests__/timer.test.ts
@@ -105,37 +105,6 @@ describe('Timer - Happy Path', () => {
       expect(() => Timer(Number.MAX_SAFE_INTEGER + 1, events)).toThrow('initialSeconds exceeds maximum safe integer');
     });
 
-    it('should validate events object is provided', () => {
-      expect(() => Timer(60, null as any)).toThrow('events must be an object');
-      expect(() => Timer(60, undefined as any)).toThrow('events must be an object');
-      expect(() => Timer(60, 'invalid' as any)).toThrow('events must be an object');
-    });
-
-    it('should validate all event callbacks are functions', () => {
-      expect(() =>
-        Timer(60, {
-          onTick: 'not a function' as any,
-          onComplete: vi.fn(),
-          onError: vi.fn(),
-        })
-      ).toThrow('events.onTick must be a function');
-
-      expect(() =>
-        Timer(60, {
-          onTick: vi.fn(),
-          onComplete: 'not a function' as any,
-          onError: vi.fn(),
-        })
-      ).toThrow('events.onComplete must be a function');
-
-      expect(() =>
-        Timer(60, {
-          onTick: vi.fn(),
-          onComplete: vi.fn(),
-          onError: 'not a function' as any,
-        })
-      ).toThrow('events.onError must be a function');
-    });
   });
 
   describe('Start functionality', () => {

--- a/packages/core/src/api/countdown-engine.ts
+++ b/packages/core/src/api/countdown-engine.ts
@@ -118,7 +118,7 @@ function computeParts(totalSeconds: number): CountdownParts {
   };
 }
 
-function buildSnapshot(initialSeconds: number, totalSeconds: number, state: TimerState): CountdownSnapshot {
+export function buildSnapshot(initialSeconds: number, totalSeconds: number, state: TimerState): CountdownSnapshot {
   const parts = computeParts(totalSeconds);
   return {
     initialSeconds,

--- a/packages/core/src/api/countdown.ts
+++ b/packages/core/src/api/countdown.ts
@@ -3,8 +3,9 @@ import { TimerState } from '../state/state-machine';
 import { Formatter } from '../format/formatter';
 
 export interface CountdownOptions {
-  onUpdate?: (minutes: string, seconds: string) => void;
+  onSnapshot?: (snapshot: CountdownSnapshot) => void;
   onStateChange?: (state: TimerState) => void;
+  onError?: (error: Error) => void;
 }
 
 export interface CountdownInstance {
@@ -25,30 +26,38 @@ export interface CountdownInstance {
 }
 
 export function Countdown(initialSeconds: number, options: CountdownOptions = {}): CountdownInstance {
-  const { onUpdate, onStateChange } = options;
+  const { onSnapshot, onStateChange, onError } = options;
 
-  if (onUpdate !== undefined && typeof onUpdate !== 'function') {
-    throw new Error('onUpdate must be a function');
+  if (onSnapshot !== undefined && typeof onSnapshot !== 'function') {
+    throw new Error('onSnapshot must be a function');
   }
 
   if (onStateChange !== undefined && typeof onStateChange !== 'function') {
     throw new Error('onStateChange must be a function');
   }
 
+  if (onError !== undefined && typeof onError !== 'function') {
+    throw new Error('onError must be a function');
+  }
+
   const formatter = Formatter();
-  const engine = CountdownEngine(initialSeconds);
+  const engine = CountdownEngine(initialSeconds, { onError });
 
   let lastSnapshot = engine.getSnapshot();
   let lastState = lastSnapshot.state;
   let lastNotifiedSeconds = Number.NaN;
 
-  const notifyUpdate = (snapshot: CountdownSnapshot) => {
-    if (!onUpdate) return;
+  const handleError = (error: Error) => {
+    if (!onError) return;
+    try { onError(error); } catch { /* ignore handler errors */ }
+  };
+
+  const notifySnapshot = (snapshot: CountdownSnapshot) => {
+    if (!onSnapshot) return;
     try {
-      const { minutes, seconds } = formatter.formatTime(snapshot.totalSeconds);
-      onUpdate(minutes, seconds);
-    } catch {
-      // ignore consumer errors
+      onSnapshot(snapshot);
+    } catch (err) {
+      handleError(err instanceof Error ? err : new Error(String(err)));
     }
   };
 
@@ -56,8 +65,8 @@ export function Countdown(initialSeconds: number, options: CountdownOptions = {}
     if (!onStateChange) return;
     try {
       onStateChange(state);
-    } catch {
-      // ignore consumer errors
+    } catch (err) {
+      handleError(err instanceof Error ? err : new Error(String(err)));
     }
   };
 
@@ -70,101 +79,29 @@ export function Countdown(initialSeconds: number, options: CountdownOptions = {}
 
     if (snapshot.totalSeconds !== lastNotifiedSeconds) {
       lastNotifiedSeconds = snapshot.totalSeconds;
-      notifyUpdate(snapshot);
+      notifySnapshot(snapshot);
     }
   });
 
-  const safeExecute = (action: () => void) => {
-    try {
-      action();
-    } catch {
-      // swallow errors to match legacy behaviour
-    }
-  };
-
   return {
-    start: () => {
-      safeExecute(() => {
-        engine.start();
-      });
-    },
-    pause: () => {
-      safeExecute(() => {
-        engine.pause();
-      });
-    },
-    resume: () => {
-      safeExecute(() => {
-        engine.resume();
-      });
-    },
-    reset: (newInitialSeconds?: number) => {
-      safeExecute(() => {
-        engine.reset(newInitialSeconds);
-      });
-    },
-    stop: () => {
-      safeExecute(() => {
-        engine.stop();
-      });
-    },
-    getSeconds: () => {
-      try {
-        return formatter.formatSeconds(lastSnapshot.totalSeconds);
-      } catch {
-        return '00';
-      }
-    },
-    getMinutes: () => {
-      try {
-        return formatter.formatMinutes(lastSnapshot.totalSeconds);
-      } catch {
-        return '00';
-      }
-    },
-    getHours: () => {
-      try {
-        return formatter.formatHours(lastSnapshot.totalSeconds);
-      } catch {
-        return '00';
-      }
-    },
-    getDays: () => {
-      try {
-        return formatter.formatDays(lastSnapshot.totalSeconds);
-      } catch {
-        return '00';
-      }
-    },
-    getWeeks: () => {
-      try {
-        return formatter.formatWeeks(lastSnapshot.totalSeconds);
-      } catch {
-        return '00';
-      }
-    },
-    getYears: () => {
-      try {
-        return formatter.formatYears(lastSnapshot.totalSeconds);
-      } catch {
-        return '00';
-      }
-    },
-    getCurrentState: () => {
-      try {
-        return lastSnapshot.state;
-      } catch {
-        return TimerState.IDLE;
-      }
-    },
+    start: () => { engine.start(); },
+    pause: () => { engine.pause(); },
+    resume: () => { engine.resume(); },
+    reset: (newInitialSeconds?: number) => { engine.reset(newInitialSeconds); },
+    stop: () => { engine.stop(); },
+    getSeconds: () => formatter.formatSeconds(lastSnapshot.totalSeconds),
+    getMinutes: () => formatter.formatMinutes(lastSnapshot.totalSeconds),
+    getHours: () => formatter.formatHours(lastSnapshot.totalSeconds),
+    getDays: () => formatter.formatDays(lastSnapshot.totalSeconds),
+    getWeeks: () => formatter.formatWeeks(lastSnapshot.totalSeconds),
+    getYears: () => formatter.formatYears(lastSnapshot.totalSeconds),
+    getCurrentState: () => lastSnapshot.state,
     getSnapshot: () => lastSnapshot,
     destroy: () => {
-      safeExecute(() => {
-        subscription.unsubscribe();
-        engine.destroy();
-      });
+      try { subscription.unsubscribe(); } finally { engine.destroy(); }
     },
   };
 }
 
 export { TimerState };
+export type { CountdownSnapshot };

--- a/packages/core/src/format/formatter.ts
+++ b/packages/core/src/format/formatter.ts
@@ -42,15 +42,11 @@ function sanitizeSeconds(totalSeconds: number): number {
 }
 
 function safeFormat(value: number, padLength = 2): string {
-  try {
-    if (!Number.isFinite(value) || value < 0) {
-      return '0'.repeat(padLength);
-    }
-
-    return Math.floor(value).toString().padStart(padLength, '0');
-  } catch {
+  if (!Number.isFinite(value) || value < 0) {
     return '0'.repeat(padLength);
   }
+
+  return Math.floor(value).toString().padStart(padLength, '0');
 }
 
 function computeTotalMinutes(seconds: number) {
@@ -131,10 +127,44 @@ export function Formatter() {
 
 export const defaultFormatter = Formatter();
 
-export const formatTime = (target: FormatTarget) => defaultFormatter.formatTime(target);
-export const formatMinutes = (target: FormatTarget) => defaultFormatter.formatMinutes(target);
-export const formatSeconds = (target: FormatTarget) => defaultFormatter.formatSeconds(target);
-export const formatHours = (target: FormatTarget) => defaultFormatter.formatHours(target);
-export const formatDays = (target: FormatTarget) => defaultFormatter.formatDays(target);
-export const formatWeeks = (target: FormatTarget) => defaultFormatter.formatWeeks(target);
-export const formatYears = (target: FormatTarget) => defaultFormatter.formatYears(target);
+export function formatTime(target: number): { minutes: string; seconds: string };
+export function formatTime(target: Pick<CountdownSnapshot, 'totalSeconds'> | null | undefined): { minutes: string; seconds: string };
+export function formatTime(target: FormatTarget): { minutes: string; seconds: string } {
+  return defaultFormatter.formatTime(target);
+}
+
+export function formatMinutes(target: number): string;
+export function formatMinutes(target: Pick<CountdownSnapshot, 'totalSeconds'> | null | undefined): string;
+export function formatMinutes(target: FormatTarget): string {
+  return defaultFormatter.formatMinutes(target);
+}
+
+export function formatSeconds(target: number): string;
+export function formatSeconds(target: Pick<CountdownSnapshot, 'totalSeconds'> | null | undefined): string;
+export function formatSeconds(target: FormatTarget): string {
+  return defaultFormatter.formatSeconds(target);
+}
+
+export function formatHours(target: number): string;
+export function formatHours(target: Pick<CountdownSnapshot, 'totalSeconds'> | null | undefined): string;
+export function formatHours(target: FormatTarget): string {
+  return defaultFormatter.formatHours(target);
+}
+
+export function formatDays(target: number): string;
+export function formatDays(target: Pick<CountdownSnapshot, 'totalSeconds'> | null | undefined): string;
+export function formatDays(target: FormatTarget): string {
+  return defaultFormatter.formatDays(target);
+}
+
+export function formatWeeks(target: number): string;
+export function formatWeeks(target: Pick<CountdownSnapshot, 'totalSeconds'> | null | undefined): string;
+export function formatWeeks(target: FormatTarget): string {
+  return defaultFormatter.formatWeeks(target);
+}
+
+export function formatYears(target: number): string;
+export function formatYears(target: Pick<CountdownSnapshot, 'totalSeconds'> | null | undefined): string;
+export function formatYears(target: FormatTarget): string {
+  return defaultFormatter.formatYears(target);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export type { CountdownInstance, CountdownOptions } from './api/countdown'
 
 export {
   CountdownEngine,
+  buildSnapshot,
   type CountdownEngineInstance,
   type CountdownEngineOptions,
   type CountdownSnapshot,

--- a/packages/core/src/runtime/timer.ts
+++ b/packages/core/src/runtime/timer.ts
@@ -29,6 +29,11 @@ export interface TimerInstance {
   destroy: () => void;
 }
 
+/**
+ * @internal — Use CountdownEngine instead. This is a low-level primitive not
+ * intended to be called directly by consumers. The `events` parameter is
+ * always provided by CountdownEngine and is guaranteed to be valid.
+ */
 export function Timer(initialSeconds: number, events: TimerEvents, config: TimerConfig = {}): TimerInstance {
   if (typeof initialSeconds !== 'number' || !Number.isFinite(initialSeconds)) {
     throw new Error('initialSeconds must be a finite number');
@@ -40,22 +45,6 @@ export function Timer(initialSeconds: number, events: TimerEvents, config: Timer
 
   if (initialSeconds > Number.MAX_SAFE_INTEGER) {
     throw new Error('initialSeconds exceeds maximum safe integer');
-  }
-
-  if (!events || typeof events !== 'object') {
-    throw new Error('events must be an object');
-  }
-
-  if (typeof events.onTick !== 'function') {
-    throw new Error('events.onTick must be a function');
-  }
-
-  if (typeof events.onComplete !== 'function') {
-    throw new Error('events.onComplete must be a function');
-  }
-
-  if (typeof events.onError !== 'function') {
-    throw new Error('events.onError must be a function');
   }
 
   let totalSeconds = Math.floor(Math.max(0, initialSeconds));

--- a/packages/react/src/use-countdown.ts
+++ b/packages/react/src/use-countdown.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   CountdownEngine,
+  buildSnapshot,
   type CountdownEngineInstance,
   type CountdownEngineOptions,
   type CountdownSnapshot,
@@ -32,26 +33,13 @@ export interface UseCountdownResult extends UseCountdownControls {
   isCompleted: boolean;
 }
 
-const buildInitialSnapshot = (
-  initialSeconds: number,
-  options: Pick<UseCountdownOptions, 'tickIntervalMs' | 'timeProvider'>
-): CountdownSnapshot => {
-  const engine = CountdownEngine(initialSeconds, {
-    tickIntervalMs: options.tickIntervalMs,
-    timeProvider: options.timeProvider,
-  });
-  const snapshot = engine.getSnapshot();
-  engine.destroy();
-  return snapshot;
-};
-
 export function useCountdown(initialSeconds: number, options: UseCountdownOptions = {}): UseCountdownResult {
   const { autoStart = false, tickIntervalMs, timeProvider, onSnapshot, onStateChange, onError } = options;
 
   const handlersRef = useRef({ onSnapshot, onStateChange, onError });
   const engineRef = useRef<CountdownEngineInstance | null>(null);
   const [snapshot, setSnapshot] = useState<CountdownSnapshot>(() =>
-    buildInitialSnapshot(initialSeconds, { tickIntervalMs, timeProvider })
+    buildSnapshot(initialSeconds, initialSeconds, TimerState.IDLE)
   );
 
   useEffect(() => {
@@ -111,7 +99,7 @@ export function useCountdown(initialSeconds: number, options: UseCountdownOption
   const pause = useCallback(() => invoke(engine => engine.pause(), false), [invoke]);
   const resume = useCallback(() => invoke(engine => engine.resume(), false), [invoke]);
   const stop = useCallback(() => invoke(engine => engine.stop(), false), [invoke]);
-  const setSeconds = useCallback((value: number) => invoke(engine => engine.setSeconds(value), undefined), [invoke]);
+  const setSeconds = useCallback((value: number): void => { invoke(engine => engine.setSeconds(value), undefined); }, [invoke]);
   const reset = useCallback(
     (nextInitialSeconds?: number) => invoke(engine => engine.reset(nextInitialSeconds), false),
     [invoke]

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -1,6 +1,13 @@
 import { defineConfig } from 'vitest/config'
+import { resolve } from 'path'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@timekeeper-countdown/core/testing-utils': resolve(__dirname, '../core/testing-utils/index.ts'),
+      '@timekeeper-countdown/core': resolve(__dirname, '../core/src/index.ts'),
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary

- Rename `onUpdate` callback to `onSnapshot` in `Countdown` high-level API for consistency with `CountdownEngine`
- Add `onError` callback support to `Countdown`
- Add function overloads to all format helpers (`formatTime`, `formatMinutes`, etc.) for better TypeScript DX
- Remove redundant `try-catch` in `safeFormat` and `safeExecute` wrappers
- Remove internal-only validation in `Timer` (events parameter is always provided by `CountdownEngine`)
- Fix ESLint config: remove nonexistent `@typescript-eslint/semi` rule, migrate to `defineConfig`
- Export `Countdown` from core index
- Add path aliases to React vitest config
- Clean up and consolidate test suites (-1081 lines net)

## Test plan

- [ ] `npm test --workspace=packages/core` passes
- [ ] `npm test --workspace=packages/react` passes
- [ ] `npm run typecheck --workspaces` passes
- [ ] `npm run lint --workspaces` passes