### PR TITLE
chore: add repository and homepage metadata to react package

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,6 +2,16 @@
   "name": "@timekeeper-countdown/react",
   "version": "0.1.4",
   "description": "React adapter for the Timekeeper Countdown engine",
+  "author": "Eduardo Kohn",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/eagle-head/timekeeper-countdown.git"
+  },
+  "homepage": "https://eagle-head.github.io/timekeeper-countdown/",
+  "bugs": {
+    "url": "https://github.com/eagle-head/timekeeper-countdown/issues"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Add `author`, `license`, `repository`, `homepage`, and `bugs` fields to `packages/react/package.json`
- These fields were already present in the core package but missing from react
- Makes repository and homepage links visible on the npm registry page

## Test plan

- [x] No code changes, metadata only