### PR TITLE
docs: prepare v0.3.0 docs for release

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -23,7 +23,7 @@ Creates a countdown engine instance and wires it into React state.
 - `options?: UseCountdownOptions`
   - `autoStart?: boolean` – start automatically on mount (default `false`).
   - `tickIntervalMs?: number` – polling interval in milliseconds (default `100`).
-- `timeProvider?: TimeProvider | (() => number)` – inject a custom clock (`TimeProvider` is exported from `@timekeeper-countdown/core`).
+- `timeProvider?: (() => number) | TimeProvider` – inject a custom clock; the simplest form is a function returning monotonically increasing milliseconds. (The `TimeProvider` object interface is internal and is **not** exported from the public barrel; for deterministic clocks use `toTimeProvider()` from `@timekeeper-countdown/core/testing-utils`.)
   - `onSnapshot?: (snapshot: CountdownSnapshot) => void` – side effects on every snapshot.
   - `onStateChange?: (state: TimerState, snapshot: CountdownSnapshot) => void` – notified whenever the state machine transitions.
   - `onError?: (error: Error) => void` – capture unexpected engine errors.
@@ -133,22 +133,31 @@ import {
 - `TimerState` – re-exported for convenience.
 
 ```ts
+// Driving the engine deterministically uses your test runner's fake timers
+// (Vitest shown) to fire the engine's internal interval AFTER advancing the
+// injected clock — `getSnapshot()` only refreshes when a tick or transition fires.
+import { vi } from 'vitest';
+
+vi.useFakeTimers();
+
 const fake = createFakeTimeProvider({ startMs: 0, tickMs: 1000 });
 const engine = CountdownEngine(5, {
   timeProvider: toTimeProvider(fake),
-  tickIntervalMs: 5,
+  tickIntervalMs: 10,
 });
 
 engine.start();
-fake.advance(3000);
 
+fake.advance(3000); // advance the injected clock 3s
+vi.advanceTimersByTime(10); // fire the interval so the snapshot refreshes
 assertRemainingSeconds(engine.getSnapshot(), 2);
 assertSnapshotState(engine.getSnapshot(), TimerState.RUNNING);
 
-fake.advance(2000);
+fake.advance(2000); // 2s more -> reaches zero
+vi.advanceTimersByTime(10); // drive the final tick -> completion
 assertSnapshotCompleted(engine.getSnapshot());
 
-// Sequence for formatter tests
+// buildSnapshotSequence is pure (no timers) — handy for formatter tests
 const sequence = buildSnapshotSequence({ totalSeconds: 4, step: 2, count: 3 });
 assertSnapshotState(sequence[0], TimerState.RUNNING);
 assertSnapshotCompleted(sequence[2]);

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,13 +8,16 @@ Both packages are versioned in lockstep and always share one version.
 
 ## @timekeeper-countdown/core
 
-### [0.3.0] - 2026-06-26
+### [0.3.0] - 2026-06-27
 
 #### Changed
 
+- **Single-emit per transition (behavior change):** each state transition (`start`/`pause`/`resume`/`stop` and natural completion) now emits exactly one snapshot; redundant emissions were removed. Consumers relying on the previous (larger) number of `onSnapshot`/`onStateChange` callbacks per transition must update.
 - The unit breakdown (`years`/`weeks`/`days`/…, the standalone `formatDays`/`formatWeeks`/`formatYears`, and `getDays`/`getWeeks`/`getYears`) is now computed by a single lossless successive-subtraction ladder (year = 365 days, week = 7 days), so the parts always reconstruct the total. **Behavior change:** values around the 52-week / 365-day boundaries are now corrected — e.g. 364 days no longer renders as all-zero.
 - `CountdownEngine.setSeconds(n)` now validates its argument like the constructor and `reset(n)`: it **throws** on a negative / non-finite / non-integer / out-of-range value instead of silently coercing it. Valid values behave as before.
+- `buildSnapshot` now sanitizes **both** `initialSeconds` and `totalSeconds` (non-finite/negative → 0, floored, capped at `MAX_SAFE_INTEGER`) and derives `isCompleted` from the clamped total, so every snapshot is self-consistent. **Behavior change:** callers that previously read back a raw/oversized/non-integer `initialSeconds` now receive the clamped value.
 - A single canonical `decompose()` is now shared by the engine, the formatters, and the published testing utilities (removing three divergent copies).
+- **Raised the minimum supported Node to `>=22`** (was `>=18`), declared via the `engines` field, so installing on older Node emits a warning or fails under `engine-strict`.
 
 #### Fixed
 
@@ -63,11 +66,13 @@ Both packages are versioned in lockstep and always share one version.
 
 ## @timekeeper-countdown/react
 
-### [0.3.0] - 2026-06-26
+### [0.3.0] - 2026-06-27
 
 #### Changed
 
-- The `useCountdown` hook inherits the engine hardening (see `@timekeeper-countdown/core` 0.3.0): a hostile `timeProvider` (`NaN`/`Infinity`/backward clock) can no longer corrupt the countdown, `tickIntervalMs` is sanitized, and the time decomposition is lossless. **Behavior change:** the hook's `setSeconds(value)` and `reset(value)` now **throw** on an invalid argument (negative / non-finite / non-integer / out-of-range) instead of silently coercing it.
+- The `useCountdown` hook inherits the engine hardening (see `@timekeeper-countdown/core` 0.3.0): a hostile `timeProvider` (`NaN`/`Infinity`/backward clock) can no longer corrupt the countdown, `tickIntervalMs` is sanitized, and the time decomposition is lossless. **Behavior change:** the hook's `setSeconds(value)` now **throws** on an invalid argument (negative / non-finite / non-integer / out-of-range) instead of silently coercing it; `reset(value)` and construction already threw in 0.2.0 (unchanged).
+- **Single-emit per transition (behavior change):** `useCountdown` now receives exactly one snapshot per engine state transition (redundant emissions removed), which can break consumers that relied on the previous number of update callbacks per transition.
+- **Now declares `engines.node` `>=22`** (the package previously declared no `engines` field); installing on older Node emits a warning or fails under `engine-strict`.
 - Bumped `@timekeeper-countdown/core` to `^0.3.0`.
 
 ### [0.2.0] - 2026-03-03
@@ -109,5 +114,3 @@ Both packages are versioned in lockstep and always share one version.
 #### Added
 
 - Initial React adapter (`useCountdown`) for the 0.1.0 React-first release.
-</content>
-</invoke>

--- a/docs/core-usage.md
+++ b/docs/core-usage.md
@@ -41,7 +41,7 @@ countdown.start();
 Available methods:
 
 ```ts
-countdown.start();                   // boolean (false when invalid transition)
+countdown.start();                   // void (the low-level CountdownEngine returns boolean)
 countdown.pause();
 countdown.resume();
 countdown.reset(nextInitialSeconds?);

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -170,26 +170,34 @@ const sequence = buildSnapshotSequence({ totalSeconds: 10, step: 5, count: 3 });
 ### Deterministic test with engine (plain core, no React)
 
 ```ts
+import { vi } from 'vitest';
 import { CountdownEngine } from '@timekeeper-countdown/core';
 import {
   createFakeTimeProvider,
   toTimeProvider,
   assertRemainingSeconds,
   assertSnapshotCompleted,
-  TimerState,
 } from '@timekeeper-countdown/core/testing-utils';
+
+// Deterministic engine tests advance the injected clock AND fire the engine's
+// internal interval with your runner's fake timers (Vitest shown), because
+// `getSnapshot()` only refreshes on a tick or a state transition.
+vi.useFakeTimers();
 
 const fake = createFakeTimeProvider({ startMs: 0, tickMs: 1000 });
 const engine = CountdownEngine(5, {
   timeProvider: toTimeProvider(fake),
-  tickIntervalMs: 5,
+  tickIntervalMs: 10,
 });
 
 engine.start();
-fake.advance(3000); // advance 3 seconds
+
+fake.advance(3000); // advance the injected clock 3 seconds
+vi.advanceTimersByTime(10); // fire the interval so getSnapshot() refreshes
 assertRemainingSeconds(engine.getSnapshot(), 2);
 
-fake.advance(2000); // advance 2 more seconds
+fake.advance(2000); // 2 more seconds -> reaches zero
+vi.advanceTimersByTime(10); // drive the final tick -> completion
 assertSnapshotCompleted(engine.getSnapshot());
 ```
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -8,7 +8,7 @@ Install `@timekeeper-countdown/react`. It bundles the countdown engine and expos
 
 ### 2. Does the library depend on React?
 
-Yes. The published package targets React 17+ and lists `react`/`react-dom` as peer dependencies. Future adapters will target their respective frameworks.
+Yes. The published package targets React 17+ and declares `react` (`>=17.0.0`) as its only peer dependency. Future adapters will target their respective frameworks.
 
 ### 3. What timer states can I expect?
 

--- a/docs/react-integration.md
+++ b/docs/react-integration.md
@@ -8,7 +8,7 @@
 npm install @timekeeper-countdown/react
 ```
 
-The hook lists `react` and `react-dom` as peer dependencies (React 17+). The shared engine and helper utilities are bundled automatically.
+The hook lists `react` (React 17+) as its only peer dependency. The shared engine and helper utilities are bundled automatically.
 
 ## Basic Hook Usage
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -7,13 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.0] - 2026-06-26
+## [0.3.0] - 2026-06-27
 
 ### Changed
 
+- **Single-emit per transition (behavior change):** each state transition (`start`/`pause`/`resume`/`stop` and natural completion) now emits exactly one snapshot; redundant emissions were removed. Consumers relying on the previous (larger) number of `onSnapshot`/`onStateChange` callbacks per transition must update.
 - The unit breakdown (`years`/`weeks`/`days`/…, the standalone `formatDays`/`formatWeeks`/`formatYears`, and `getDays`/`getWeeks`/`getYears`) is now computed by a single lossless successive-subtraction ladder (year = 365 days, week = 7 days), so the parts always reconstruct the total. **Behavior change:** values around the 52-week / 365-day boundaries are now corrected — e.g. 364 days no longer renders as all-zero.
 - `CountdownEngine.setSeconds(n)` now validates its argument like the constructor and `reset(n)`: it **throws** on a negative / non-finite / non-integer / out-of-range value instead of silently coercing it. Valid values behave as before.
+- `buildSnapshot` now sanitizes **both** `initialSeconds` and `totalSeconds` (non-finite/negative → 0, floored, capped at `MAX_SAFE_INTEGER`) and derives `isCompleted` from the clamped total, so every snapshot is self-consistent. **Behavior change:** callers that previously read back a raw/oversized/non-integer `initialSeconds` now receive the clamped value.
 - A single canonical `decompose()` is now shared by the engine, the formatters, and the published testing utilities (removing three divergent copies).
+- **Raised the minimum supported Node to `>=22`** (was `>=18`), declared via the `engines` field, so installing on older Node emits a warning or fails under `engine-strict`.
 
 ### Fixed
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -55,7 +55,7 @@ countdown.start(); // Begin the countdown
 `Countdown` wraps the lower-level engine and returns convenient methods:
 
 ```ts
-countdown.start();                   // boolean (false when invalid transition)
+countdown.start();                   // void (the low-level CountdownEngine returns boolean)
 countdown.pause();
 countdown.resume();
 countdown.reset(nextInitialSeconds?);

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.0] - 2026-06-26
+## [0.3.0] - 2026-06-27
 
 ### Changed
 
-- The `useCountdown` hook inherits the engine hardening (see `@timekeeper-countdown/core` 0.3.0): a hostile `timeProvider` (`NaN`/`Infinity`/backward clock) can no longer corrupt the countdown, `tickIntervalMs` is sanitized, and the time decomposition is lossless. **Behavior change:** the hook's `setSeconds(value)` and `reset(value)` now **throw** on an invalid argument (negative / non-finite / non-integer / out-of-range) instead of silently coercing it.
+- The `useCountdown` hook inherits the engine hardening (see `@timekeeper-countdown/core` 0.3.0): a hostile `timeProvider` (`NaN`/`Infinity`/backward clock) can no longer corrupt the countdown, `tickIntervalMs` is sanitized, and the time decomposition is lossless. **Behavior change:** the hook's `setSeconds(value)` now **throws** on an invalid argument (negative / non-finite / non-integer / out-of-range) instead of silently coercing it; `reset(value)` and construction already threw in 0.2.0 (unchanged).
+- **Single-emit per transition (behavior change):** `useCountdown` now receives exactly one snapshot per engine state transition (redundant emissions removed), which can break consumers that relied on the previous number of update callbacks per transition.
+- **Now declares `engines.node` `>=22`** (the package previously declared no `engines` field); installing on older Node emits a warning or fails under `engine-strict`.
 - Bumped `@timekeeper-countdown/core` to `^0.3.0`.
 
 ## [0.2.0] - 2026-03-03

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -196,7 +196,7 @@ The core package ships several helpers under `@timekeeper-countdown/core/testing
 - `assertRemainingSeconds(snapshot, expected, tolerance?, message?)` — throws if remaining seconds differ beyond tolerance.
 - `TimerState` — re-exported for convenience (`IDLE`, `RUNNING`, `PAUSED`, `STOPPED`).
 
-See the [core README](https://github.com/eagle-head/timekeeper-countdown/tree/main/packages/core#testing-utilities) or [API Reference](https://eagle-head.github.io/timekeeper-countdown/#/api-reference) for full signatures and examples.
+See the [core README](https://github.com/eagle-head/timekeeper-countdown/tree/main/packages/core#testing-utilities) or [API Reference](https://eagle-head.github.io/timekeeper-countdown/api-reference) for full signatures and examples.
 
 ---
 


### PR DESCRIPTION
## Summary

Makes the documentation accurate and self-consistent for cutting **v0.3.0**, so the release can be tagged with no further doc edits. Found by a read-only doc-readiness audit and verified against the source (and `git`) before fixing — versions/deps were already correct (`0.3.0` in both packages, `engines.node >=22`, peer `react` only), so this PR is documentation only.

## Changelogs (core + react + docs site)

- Record the breaking **minimum-Node bump** (`>=18` → `>=22` on root/core; the react package newly declares `engines.node >=22`).
- Record the **single-emit-per-transition** behavior change (each transition now emits exactly one snapshot).
- Record that **`buildSnapshot` now clamps `initialSeconds`** and derives `isCompleted` from the clamped total.
- Correct the react entry that listed `reset(value)` as newly-throwing — only `setSeconds` is new in 0.3.0 (`reset`/construction already threw in 0.2.0).
- Set the `[0.3.0]` date to `2026-06-27`.

## API docs & examples

- **Fix the broken deterministic examples** (`examples.md`, `api-reference.md`) that asserted on `getSnapshot()` without driving the engine's interval. They now use fake timers (`vi.advanceTimersByTime`) so the snapshot refreshes before each assertion. Proven with a real red→green test (old snippet fails `expected 2±0 but received 5`; fixed snippet passes).
- Remove the false claim that `TimeProvider` is a public export of `@timekeeper-countdown/core` (it is internal); point to `toTimeProvider()` from `…/testing-utils`.
- Correct the high-level `Countdown` methods documented as returning `boolean` — they return `void` (`core-usage.md`, core README). The boolean transition result is on the low-level `CountdownEngine`.
- State that only `react` (`>=17.0.0`) is a peer dependency, not `react-dom` (`faq.md`, `react-integration.md`).
- Fix the stale hash-router API Reference link in the react README (`/#/api-reference` → `/api-reference`).

## Build fix

- Remove a leaked tool-call artifact (`</content></invoke>`) at the end of `docs/changelog.md` that broke `npm run docs:build` (and therefore the docs deploy). Pre-existing on `main`; scanned all `.md` for similar artifacts — none other found.

## Verification

- `npm run docs:build` (VitePress) — passes (failed before the artifact removal).
- `bin/quality-gate.sh --full` — green (build + format:check + lint + typecheck + test; core 420, react 18).
- The corrected example is proven by an actual test (red→green), not asserted.
