### PR TITLE
fix: lower published engines.node to >=18 (release 0.3.1)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,12 @@ Both packages are versioned in lockstep and always share one version.
 
 ## @timekeeper-countdown/core
 
+### [Unreleased]
+
+#### Fixed
+
+- Lowered the published `engines.node` floor from `>=22` to `>=18`. The shipped `dist` targets es2022 and uses no Node-22-only API, so the previous floor needlessly warned (or, under `engine-strict`, blocked) installs on Node 18/20. Building and testing the library still require Node 22 (declared only at the private workspace root).
+
 ### [0.3.0] - 2026-06-27
 
 #### Changed
@@ -65,6 +71,12 @@ Both packages are versioned in lockstep and always share one version.
 ---
 
 ## @timekeeper-countdown/react
+
+### [Unreleased]
+
+#### Fixed
+
+- Lowered the published `engines.node` floor from `>=22` to `>=18` (the hook adds no Node-22 requirement of its own). Building and testing the library still require Node 22 (declared only at the private workspace root).
 
 ### [0.3.0] - 2026-06-27
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,8 @@ Both packages are versioned in lockstep and always share one version.
 
 ### [Unreleased]
 
+### [0.3.1] - 2026-06-27
+
 #### Fixed
 
 - Lowered the published `engines.node` floor from `>=22` to `>=18`. The shipped `dist` targets es2022 and uses no Node-22-only API, so the previous floor needlessly warned (or, under `engine-strict`, blocked) installs on Node 18/20. Building and testing the library still require Node 22 (declared only at the private workspace root).
@@ -73,6 +75,8 @@ Both packages are versioned in lockstep and always share one version.
 ## @timekeeper-countdown/react
 
 ### [Unreleased]
+
+### [0.3.1] - 2026-06-27
 
 #### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10279,7 +10279,7 @@
     },
     "packages/core": {
       "name": "@timekeeper-countdown/core",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -10287,10 +10287,10 @@
     },
     "packages/react": {
       "name": "@timekeeper-countdown/react",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
-        "@timekeeper-countdown/core": "^0.3.0"
+        "@timekeeper-countdown/core": "^0.3.1"
       },
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,9 +26,6 @@
         "typescript-eslint": "^8.38.0",
         "vitepress": "^1.6.4",
         "vitest": "^4.1.9"
-      },
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -10285,7 +10282,7 @@
       "version": "0.3.0",
       "license": "MIT",
       "engines": {
-        "node": ">=22"
+        "node": ">=18"
       }
     },
     "packages/react": {
@@ -10305,7 +10302,7 @@
         "react-dom": "^18.3.1"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=18"
       },
       "peerDependencies": {
         "react": ">=17.0.0"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,11 @@
     "vitepress": "^1.6.4",
     "vitest": "^4.1.9"
   },
-  "engines": {
-    "node": ">=22"
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": ">=22",
+      "onFail": "error"
+    }
   }
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Lowered the published `engines.node` floor from `>=22` to `>=18`. The shipped `dist` targets es2022 and uses no Node-22-only API, so the previous floor needlessly warned (or, under `engine-strict`, blocked) installs on Node 18/20. Building and testing the library still require Node 22 (declared only at the private workspace root).
+
 ## [0.3.0] - 2026-06-27
 
 ### Changed

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-06-27
+
 ### Fixed
 
 - Lowered the published `engines.node` floor from `>=22` to `>=18`. The shipped `dist` targets es2022 and uses no Node-22-only API, so the previous floor needlessly warned (or, under `engine-strict`, blocked) installs on Node 18/20. Building and testing the library still require Node 22 (declared only at the private workspace root).

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -21,7 +21,7 @@ The published bundle is pure ESM. When targeting CommonJS environments use a bun
 
 Supported runtimes:
 
-- Node.js 22+
+- Node.js 18+
 - Modern browsers (ES2022 modules)
 
 ---

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,7 +63,7 @@
     "prepublishOnly": "npm run build && npm run test && npm run typecheck"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=18"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@timekeeper-countdown/core",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Lightweight countdown engine that powers the Timekeeper packages. Pure TypeScript with no runtime dependencies.",
   "keywords": [
     "countdown",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Lowered the published `engines.node` floor from `>=22` to `>=18` (the hook adds no Node-22 requirement of its own). Building and testing the library still require Node 22 (declared only at the private workspace root).
+
 ## [0.3.0] - 2026-06-27
 
 ### Changed

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-06-27
+
 ### Fixed
 
 - Lowered the published `engines.node` floor from `>=22` to `>=18` (the hook adds no Node-22 requirement of its own). Building and testing the library still require Node 22 (declared only at the private workspace root).

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@timekeeper-countdown/react",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "React adapter for the Timekeeper Countdown engine",
   "author": "Eduardo Kohn",
   "license": "MIT",
@@ -45,7 +45,7 @@
     "react": ">=17.0.0"
   },
   "dependencies": {
-    "@timekeeper-countdown/core": "^0.3.0"
+    "@timekeeper-countdown/core": "^0.3.1"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -65,7 +65,7 @@
   ],
   "sideEffects": false,
   "engines": {
-    "node": ">=22"
+    "node": ">=18"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org",


### PR DESCRIPTION
## Summary

Release **0.3.1** (patch). Separates the **development** Node requirement from the **consumer** requirement, using the official npm field for each, and relaxes the published floor that 0.3.0 set too high.

0.3.0 shipped `engines.node >=22` on the published packages. But the shipped `dist` targets es2022 and uses no Node-22-only API — so that floor needlessly warned (or, under `engine-strict` / pnpm / yarn, blocked) installs on Node 18/20 with no runtime benefit. The strict Node 22 is really a *toolchain* requirement (Vitest 4 etc.), not a *runtime* one.

## Changes

- **Published `core` + `react`:** `engines.node` `>=22` → **`>=18`** (the consumer-facing field).
- **Private workspace root:** replace `engines.node >=22` with **`devEngines.runtime`** (`{ name: node, version: >=22, onFail: error }`) — the field npm documents for "people interacting with the source code", validated before `install`/`ci`/`run`.
- **`packages/core/README.md`:** "Supported runtimes" → Node.js **18+** (the only consumer doc that stated a Node minimum). `CONTRIBUTING.md` / `RELEASING.md` intentionally keep Node 22 as the development requirement.
- **Release:** lockstep bump core + react to `0.3.1` (react → core `^0.3.1`); `[0.3.1]` changelog section in all three changelogs.

## Why this is correct per the official docs

Per [npm package.json docs](https://docs.npmjs.com/cli/v11/configuring-npm/package-json/): `engines` is *"designed to alert the user when a dependency uses a different node version than the project it's being used in"* (consumer), whereas `devEngines` *"is used to alert people interacting with the source code of a project"* (dev). So `engines = >=18` (consumer) + `devEngines.runtime = >=22` (dev) is the documented split.

## Verification

- 🔴→🟢 **devEngines is actually enforced:** forcing `devEngines.runtime >=99.0.0` fails `npm install` with `EBADDEVENGINES`; `>=22` passes on Node 22. npm here is 10.9.8.
- ✅ `bin/quality-gate.sh --full` — green (build · format · lint · typecheck · 420 core + 18 react). The gate runs `npm run`, which also exercises the `devEngines` validation.
- ✅ `npm run docs:build` — green.
- ✅ `package-lock.json` reflects only the engines/version changes — no dependency churn.

## Note

SemVer: relaxing the engine floor is backward-compatible (wider install surface, no API change) → **patch**. The npm publish stays gated behind the `npm-publish` environment manual approval after the `v0.3.1` tag is pushed.
