### PR TITLE
refactor(core): decouple snapshot type from engine (v0.3.2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,8 +65,11 @@ packages/
 │   │   │   ├── timer.ts             # Timer() — setInterval-based tick at 100ms
 │   │   │   └── time-providers.ts    # High-res time abstraction (performance.now fallback)
 │   │   ├── time/
+│   │   │   ├── clamp.ts             # clampSeconds() — shared second-field sanitizer (single source of truth for clamping)
 │   │   │   ├── constants.ts         # Time math constants
 │   │   │   └── decompose.ts         # decompose() — single lossless source of truth for the year/week/day/hour/min/sec breakdown (shared by engine, formatters, testing-utils)
+│   │   ├── model/
+│   │   │   └── countdown-snapshot.ts # CountdownSnapshot type — leaf module shared by engine, formatters, testing-utils (re-exported from the package root)
 │   │   └── format/
 │   │       └── formatter.ts         # Formatter() + standalone format functions
 │   └── testing-utils/         # Published test helpers (./testing-utils export)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md) in all interact
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org/) 22 or later
+- [Node.js](https://nodejs.org/) 22 or later — required to build and test the library (the CI quality gate runs on Node 22). The published packages themselves support Node >= 18 at runtime; this higher floor applies to development only.
 - npm (comes with Node.js)
 
 ### Getting Started

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,12 @@ Both packages are versioned in lockstep and always share one version.
 
 ### [Unreleased]
 
+### [0.3.2] - 2026-07-11
+
+#### Changed
+
+- Internal refactor only — **no public API or behavior change**. The `CountdownSnapshot` type moved to its own leaf module (still exported from the package root with an identical shape); the three repeated time-validation guards in the safe time provider were consolidated into one helper (restoring a `MAX_SAFE_INTEGER` upper bound the fallback path had dropped — internal and unreachable in practice); and the published `buildSnapshot` testing helper now delegates to the engine's canonical implementation, so the test double can no longer drift from production.
+
 ### [0.3.1] - 2026-06-27
 
 #### Fixed
@@ -75,6 +81,12 @@ Both packages are versioned in lockstep and always share one version.
 ## @timekeeper-countdown/react
 
 ### [Unreleased]
+
+### [0.3.2] - 2026-07-11
+
+#### Changed
+
+- Lockstep release with `@timekeeper-countdown/core` 0.3.2 (internal refactor only — no changes to the `useCountdown` hook). Bumps the `@timekeeper-countdown/core` dependency to `^0.3.2`.
 
 ### [0.3.1] - 2026-06-27
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10279,7 +10279,7 @@
     },
     "packages/core": {
       "name": "@timekeeper-countdown/core",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -10287,10 +10287,10 @@
     },
     "packages/react": {
       "name": "@timekeeper-countdown/react",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
-        "@timekeeper-countdown/core": "^0.3.1"
+        "@timekeeper-countdown/core": "^0.3.2"
       },
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-07-11
+
+### Changed
+
+- Internal refactor only — **no public API or behavior change**. The `CountdownSnapshot` type moved to its own leaf module (still exported from the package root with an identical shape); the three repeated time-validation guards in the safe time provider were consolidated into one helper (restoring a `MAX_SAFE_INTEGER` upper bound the fallback path had dropped — internal and unreachable in practice); and the published `buildSnapshot` testing helper now delegates to the engine's canonical implementation, so the test double can no longer drift from production.
+
 ## [0.3.1] - 2026-06-27
 
 ### Fixed

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@timekeeper-countdown/core",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Lightweight countdown engine that powers the Timekeeper packages. Pure TypeScript with no runtime dependencies.",
   "keywords": [
     "countdown",

--- a/packages/core/src/__tests__/assertions-mutation.test.ts
+++ b/packages/core/src/__tests__/assertions-mutation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import type { CountdownSnapshot } from '../api/countdown-engine';
+import type { CountdownSnapshot } from '../model/countdown-snapshot';
 import {
   buildSnapshot,
   assertSnapshotState,
@@ -69,6 +69,17 @@ describe('assertions.ts mutation coverage', () => {
   });
 
   describe('assertRemainingSeconds', () => {
+    /**
+     * EQUIVALENT MUTANT (Stryker id 595) — testing-utils/assertions.ts L31:7-31:35
+     * ConditionalExpression: `typeof expected !== 'number'` -> `false`, i.e. the guard becomes
+     * `false || !Number.isFinite(expected)` === `!Number.isFinite(expected)`.
+     * Unobservable: `Number.isFinite(x)` returns false for EVERY non-number type, so
+     * `typeof x !== 'number'` always implies `!Number.isFinite(x)`. The left operand is fully
+     * subsumed by the right and can never independently decide the guard; no public-API input
+     * distinguishes the two forms. Left as an honest, explained equivalent survivor.
+     * (The byte-identical whole-`if`-test -> false sibling, id 593, IS killable and is already
+     * killed by the `rejects non-finite expected values` test below via NaN / Infinity.)
+     */
     it('rejects non-finite expected values', () => {
       const snapshot = buildSnapshot({ totalSeconds: 5, state: TimerState.RUNNING });
       expect(() => assertRemainingSeconds(snapshot, Number.NaN)).toThrow(

--- a/packages/core/src/__tests__/countdown-engine-mutation.test.ts
+++ b/packages/core/src/__tests__/countdown-engine-mutation.test.ts
@@ -129,6 +129,62 @@ describe('countdown-engine — mutation oracle', () => {
 
       e.destroy();
     });
+
+    // id 104 (ConditionalExpression -> true on `if (transitioned)`): forcing the guard
+    // true would run `timer.setSeconds(0)` even on a REJECTED stop() from IDLE, zeroing
+    // the timer's live remaining. That corruption is invisible in the (still-60) snapshot
+    // but poisons the very next start(): timer.start() early-returns false when remaining
+    // is <= 0, so the engine would silently refuse to start. Drive stop()->start() from
+    // IDLE and assert the countdown genuinely begins running.
+    it('a rejected stop() from IDLE does not poison a subsequent start()', () => {
+      let t = 0;
+      const e = CountdownEngine(60, { timeProvider: () => t, tickIntervalMs: 100 });
+
+      expect(e.stop()).toBe(false); // rejected: still IDLE
+      expect(e.getSnapshot().state).toBe(TimerState.IDLE);
+
+      // With the mutant, the rejected stop() has already set the timer to 0, so this
+      // start() returns false and the engine stays IDLE.
+      expect(e.start()).toBe(true);
+      expect(e.getSnapshot().state).toBe(TimerState.RUNNING);
+
+      // And the countdown actually advances (the timer still holds its 60s).
+      t = 1000;
+      vi.advanceTimersByTime(100);
+      expect(e.getSnapshot().totalSeconds).toBe(59);
+
+      e.destroy();
+    });
+  });
+
+  describe('reset() single-emission (line 242)', () => {
+    // id 116 (ConditionalExpression -> true on `if (!transitioned)`): forcing this true
+    // makes reset() ALWAYS call handleSnapshotUpdate — even when stateMachine.reset()
+    // already drove a real transition (RUNNING/PAUSED/STOPPED -> IDLE) whose
+    // signalStateChange emitted the IDLE snapshot. That produces a DOUBLE emission for a
+    // single reset(). The content of both emits is identical, so only the emission COUNT
+    // exposes the mutant. Subscribe, then assert exactly one IDLE snapshot per reset().
+    it('reset() from RUNNING emits the IDLE snapshot exactly once', () => {
+      const t = 0;
+      const e = CountdownEngine(60, { timeProvider: () => t, tickIntervalMs: 100 });
+
+      expect(e.start()).toBe(true);
+
+      const seen: TimerState[] = [];
+      const sub = e.subscribe(snapshot => seen.push(snapshot.state));
+      expect(seen).toEqual([TimerState.RUNNING]); // initial emit on subscribe
+      seen.length = 0;
+
+      expect(e.reset()).toBe(true);
+      // Real: one IDLE emit via signalStateChange. Mutant: a second, redundant IDLE emit
+      // via the always-run handleSnapshotUpdate.
+      expect(seen).toEqual([TimerState.IDLE]);
+      expect(e.getSnapshot().state).toBe(TimerState.IDLE);
+      expect(e.getSnapshot().totalSeconds).toBe(60);
+
+      sub.unsubscribe();
+      e.destroy();
+    });
   });
 
   describe('subscribe()/unsubscribe()/destroy() (lines 252, 259, 265)', () => {
@@ -175,4 +231,58 @@ describe('countdown-engine — mutation oracle', () => {
       expect(snap.state).toBe(TimerState.STOPPED);
     });
   });
+
+  // ── EQUIVALENT survivors (documented, intentionally not tested) ────────────────
+  // The mutants below survive because no public-API input can make the mutated code
+  // observably diverge from the real code. They are honest equivalent mutants, not
+  // oracle gaps, so per policy they are documented here rather than "killed" with a
+  // theater test. Each note states the location, the mutation, and the one-line
+  // unobservability argument.
+  //
+  // sanitizeInitialSeconds guard (line 35):
+  //   `if (typeof value !== 'number' || !Number.isFinite(value) || !Number.isInteger(value))`
+  //   The trailing `!Number.isInteger(value)` already fully decides the throw:
+  //   Number.isInteger is true ONLY for finite integer numbers, and it never coerces,
+  //   so for any value where it is true the first two operands are necessarily false,
+  //   and for any value the first two would reject (non-number / non-finite) it is true.
+  //   • id 6  — Conditional -> false on `typeof value !== 'number'`: drops the redundant
+  //     typeof operand; every non-number also fails `!Number.isFinite` (no coercion), so
+  //     the throw set is unchanged. EQUIVALENT.
+  //   • id 4  — Conditional -> false on `typeof … || !Number.isFinite(value)`: leaves
+  //     `!Number.isInteger(value)`, which is true for exactly the same inputs the full
+  //     guard threw on. EQUIVALENT.
+  //   • id 5  — LogicalOperator `||` -> `&&` between the first two operands: makes the
+  //     condition `(A && B) || C`. It differs from `A || B || C` only when C
+  //     (`!Number.isInteger`) is false, i.e. an integer number — but then A (`typeof≠number`)
+  //     and B (`!isFinite`) are both false, so `A&&B` and `A||B` are both false. EQUIVALENT.
+  //
+  // Optional callback invocations (lines 106, 131, 146):
+  //   `options.onSnapshot?.(…)`, `options.onStateChange?.(…)`, `options.onError?.(…)`
+  //   • id 59 / id 67 / id 71 — OptionalChaining removed. Each call is the SOLE statement
+  //     inside a `try { } catch {}` whose catch body is empty. Dropping `?.` changes
+  //     behavior only when the callback is null/undefined, where the mutant throws a
+  //     TypeError — which is immediately swallowed by the empty catch, with nothing after
+  //     it in the try to skip. When the callback is a function both forms call it
+  //     identically. No public input observably diverges. EQUIVALENT. (Corroborated: the
+  //     existing suite drives ticks/transitions/errors with these callbacks omitted, and
+  //     all three mutants still survived.)
+  //
+  // pause() guard (line 194): `if (!stateMachine.canPause()) return false;`
+  //   • id 91 (Conditional -> false) / id 92 (BlockStatement -> {}) — both delete the early
+  //     `return false`, letting pause() fall through to `timer.stop(); return
+  //     stateMachine.pause()`. canPause() is false only in IDLE/PAUSED/STOPPED; the engine
+  //     invariant "timer runs ⟺ state === RUNNING" makes timer.stop() a no-op in those
+  //     states, and stateMachine.pause() rejects the invalid transition (returns false,
+  //     emits no snapshot). So pause() still returns false with no state change — identical
+  //     to the guarded path. EQUIVALENT.
+  //
+  // stop() bookkeeping (line 218): `if (transitioned) { timer.setSeconds(0); }`
+  //   • id 105 (Conditional -> false) / id 106 (BlockStatement -> {}) — both skip
+  //     `timer.setSeconds(0)` after a SUCCESSFUL stop(). But a successful stop already
+  //     emitted a STOPPED snapshot reporting 0 via signalStateChange, so getSnapshot() is 0
+  //     regardless. Skipping the call only leaves the timer's internal remaining stale, and
+  //     from STOPPED every path that could surface it (reset / setSeconds / destroy)
+  //     overwrites the timer before reading it. Never observable. EQUIVALENT. (Contrast
+  //     id 104 above — Conditional -> true — which IS killable: it runs setSeconds(0) on a
+  //     REJECTED stop from IDLE, poisoning the next start().)
 });

--- a/packages/core/src/__tests__/countdown-mutation.test.ts
+++ b/packages/core/src/__tests__/countdown-mutation.test.ts
@@ -158,3 +158,23 @@ describe('Countdown - mutation coverage (engine wiring)', () => {
     vi.doUnmock('../runtime/timer');
   });
 });
+
+/*
+ * DOCUMENTED EQUIVALENT MUTANT (proven unkillable — intentionally NOT tested).
+ *
+ * src/api/countdown.ts L52  ConditionalExpression -> false
+ *   handleError's guard `if (!onError) return;` -> `if (false) return;`.
+ *
+ * handleError is only ever called from the catch blocks of notifySnapshot /
+ * notifyStateChange, i.e. when a user onSnapshot/onStateChange callback throws.
+ * The guard only matters when `onError` is falsy — and the constructor validates
+ * onError to be either undefined or a function, so `!onError` is true exactly when
+ * onError is undefined. In that case:
+ *   - real code: returns early, no-op.
+ *   - mutant: proceeds to `try { onError(error) }` where onError is undefined, so
+ *     `undefined(error)` throws a TypeError which the surrounding
+ *     `catch { /* ignore *\/ }` immediately swallows — also a no-op.
+ * Both paths produce no external effect (no callback fires, nothing re-throws, the
+ * timer keeps running); when onError IS defined both paths call it identically.
+ * No public-API input distinguishes them. => EQUIVALENT.
+ */

--- a/packages/core/src/__tests__/fake-time-mutation.test.ts
+++ b/packages/core/src/__tests__/fake-time-mutation.test.ts
@@ -32,3 +32,20 @@ describe('createFakeTimeProvider — highResolution default (mutant 664)', () =>
     expect(fake.isHighResolution).toBe(false);
   });
 });
+
+/**
+ * EQUIVALENT MUTANTS in testing-utils/fake-time.ts `clamp()` — left as honest, explained
+ * survivors because no public-API input can observe a difference (see Stryker report):
+ *
+ *  - L17:34 EqualityOperator `value < 0` -> `value <= 0` (Survived).
+ *    Differs only at `value === 0`. Real path: `0 < 0` is false, so it falls through to the
+ *    else-branch `Math.floor(0)` === 0; the mutant returns the literal 0 directly. Both yield 0,
+ *    so `now()`/`set()`/`reset()` produce the same value for every finite input. (The only
+ *    numeric distinguisher is -0 vs +0 via Object.is — not a meaningful millisecond distinction,
+ *    both are zero ms.)
+ *
+ *  - L20:7 EqualityOperator `value > Number.MAX_SAFE_INTEGER` -> `value >= Number.MAX_SAFE_INTEGER`
+ *    (Survived). Differs only at `value === Number.MAX_SAFE_INTEGER`, which is an integer. Real
+ *    path: `MAX > MAX` is false, so it falls through to `Math.floor(MAX)` === MAX; the mutant
+ *    returns the literal MAX. Both yield exactly MAX, so no input distinguishes them.
+ */

--- a/packages/core/src/__tests__/formatter-mutation.test.ts
+++ b/packages/core/src/__tests__/formatter-mutation.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { Formatter, formatSeconds as formatSecondsDirect } from '../format/formatter';
+import { buildSnapshot } from '../api/countdown-engine';
+import { TimerState } from '../state/state-machine';
 
 /**
  * Mutation-killing tests for src/format/formatter.ts.
@@ -50,3 +52,68 @@ describe('Formatter mutation killers', () => {
     });
   });
 });
+
+describe('clampSeconds negative-zero normalization (clamp.ts line 19, via buildSnapshot)', () => {
+  // Mutant: EqualityOperator `value <= 0` -> `value < 0` in clampSeconds.
+  //
+  // The two operators disagree on exactly one finite input: negative zero. Every
+  // other value <= 0 collapses to +0 under BOTH operators (for any strictly-negative
+  // v, `v < 0` is true, so the mutant still returns 0), and every positive value
+  // falls through under both. So -0 is the SOLE input that distinguishes them:
+  //   - real: `-0 <= 0` is true  -> returns the canonical +0 literal.
+  //   - mutant: `-0 < 0` is false -> falls through to `return Math.floor(-0)`, == -0.
+  //
+  // A snapshot must store a canonical non-negative integer, so a -0 total must be
+  // normalized to +0. Object.is (which Vitest's toBe uses) distinguishes -0 from +0,
+  // making the mutant observable through the public buildSnapshot API.
+  it('stores canonical +0 (not -0) when the total is negative zero', () => {
+    const negativeZero = -0;
+    // Guard: make sure the fixture really is -0 (not constant-folded to +0), otherwise
+    // the assertions below would not exercise the divergent branch at all.
+    expect(Object.is(negativeZero, -0)).toBe(true);
+
+    const snapshot = buildSnapshot(0, negativeZero, TimerState.STOPPED);
+
+    // Load-bearing: real code yields +0 here; the mutant yields -0 -> these fail.
+    expect(Object.is(snapshot.totalSeconds, 0)).toBe(true);
+    expect(Object.is(snapshot.totalSeconds, -0)).toBe(false);
+
+    // The rest of the snapshot stays canonical and completed under the real code.
+    expect(snapshot.isCompleted).toBe(true);
+    expect(snapshot.parts.seconds).toBe(0);
+  });
+});
+
+/*
+ * DOCUMENTED EQUIVALENT MUTANTS (proven unkillable — intentionally NOT tested).
+ *
+ * These survivors in this cluster (clamp.ts + formatter.ts) are observationally
+ * identical to the real code: no public-API input distinguishes them, so writing a
+ * "killing" test is impossible and any green test targeting them would be theater.
+ *
+ * 1. src/time/clamp.ts L23  EqualityOperator  `value >= MAX` -> `value > MAX`
+ *    The only input the operators disagree on is value === Number.MAX_SAFE_INTEGER:
+ *    the real guard returns MAX directly, while the mutant falls through to
+ *    `return Math.floor(MAX)`. MAX_SAFE_INTEGER (2^53 - 1) is an integer, so
+ *    Math.floor(MAX) === MAX — identical result (and MAX is positive, so no -0
+ *    edge exists here as it does on line 19). => EQUIVALENT.
+ *
+ * 2. src/format/formatter.ts L12  ConditionalExpression -> true
+ *    `if (target && typeof target.totalSeconds === 'number')` -> `if (target && true)`.
+ *    The branches diverge only when `target` is truthy AND `target.totalSeconds` is
+ *    NOT a number: the real code returns 0, the mutant returns that non-number value.
+ *    But extractSeconds' result is ALWAYS funnelled through clampSeconds (partsOf =
+ *    decompose(clampSeconds(extractSeconds(target)))), and clampSeconds' own type
+ *    guard (`typeof value !== 'number'`) collapses any non-number back to 0 — the same
+ *    value the real branch returns. Every divergent input therefore yields identical
+ *    "00" output across all formatters. (The property read cannot throw differently:
+ *    the real condition reads `target.totalSeconds` too.) => EQUIVALENT.
+ *
+ * 3. src/time/clamp.ts L15  ConditionalExpression -> false  (first operand `typeof value !== 'number'`)
+ *    The guard is `typeof value !== 'number' || !Number.isFinite(value)`. Dropping the typeof
+ *    operand leaves `!Number.isFinite(value)`, which is already true for EVERY non-number
+ *    (Number.isFinite never coerces), so any input the typeof clause caught the finite clause
+ *    catches too — the identical early `return 0` fires. The typeof operand is redundant
+ *    defense-in-depth. => EQUIVALENT. (This mutant flips between Timeout/Survived across Stryker
+ *    runs due to interval-test timeout nondeterminism; it is unkillable either way.)
+ */

--- a/packages/core/src/__tests__/snapshots-contract.test.ts
+++ b/packages/core/src/__tests__/snapshots-contract.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { buildSnapshot } from '../../testing-utils';
+import { buildSnapshot as engineBuildSnapshot } from '../api/countdown-engine';
+import { clampSeconds } from '../time/clamp';
+import { TimerState } from '../state/state-machine';
+
+/**
+ * Adapter-contract property for testing-utils/snapshots.ts (item 2 refactor).
+ *
+ * `buildSnapshot` was rewritten as a thin ADAPTER: it owns ONLY the ergonomic option-bag
+ * resolution (the initial/total cross-fallback chains and the default-state heuristic) and
+ * DELEGATES every snapshot invariant (clamp, decompose -> parts, isRunning, isCompleted) to
+ * the engine's canonical buildSnapshot — the single source of truth. This property machine-
+ * checks that delegation: for ANY option bag, the adapter's output must deep-equal the engine
+ * building from the resolved (initial, total, state) triple. Re-implementing any invariant
+ * inside snapshots.ts (drift from production) would break this equality.
+ */
+describe('snapshots.ts adapter contract — single source of truth (property)', () => {
+  const secondsArb = fc.oneof(
+    fc.integer({ min: -10, max: 40 * 365 * 24 * 3600 }),
+    fc.double(),
+    fc.constantFrom(
+      0,
+      -0,
+      -1,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+      Number.MAX_SAFE_INTEGER,
+      Number.MAX_SAFE_INTEGER + 1,
+      10.5,
+      45,
+      90
+    )
+  );
+  const stateArb = fc.constantFrom(TimerState.IDLE, TimerState.RUNNING, TimerState.PAUSED, TimerState.STOPPED);
+
+  it('buildSnapshot(opts) deep-equals engine buildSnapshot(resolved initial/total/state) for ANY options', () => {
+    fc.assert(
+      fc.property(
+        fc.record({
+          initialSeconds: fc.option(secondsArb, { nil: undefined }),
+          totalSeconds: fc.option(secondsArb, { nil: undefined }),
+          state: fc.option(stateArb, { nil: undefined }),
+        }),
+        opts => {
+          // Re-derive ONLY the adapter's ergonomic resolution (fallback chains + state
+          // heuristic). Every invariant (clamp, decompose -> parts, isRunning/isCompleted)
+          // must come from the engine, so this expectation can never drift from production.
+          const resolvedInitial = opts.initialSeconds ?? opts.totalSeconds ?? 0;
+          const resolvedTotal = opts.totalSeconds ?? opts.initialSeconds ?? 0;
+          const resolvedState = opts.state ?? (clampSeconds(resolvedTotal) > 0 ? TimerState.IDLE : TimerState.STOPPED);
+          expect(buildSnapshot(opts)).toEqual(engineBuildSnapshot(resolvedInitial, resolvedTotal, resolvedState));
+        }
+      ),
+      { numRuns: 1000 }
+    );
+  });
+});

--- a/packages/core/src/__tests__/snapshots-mutation.test.ts
+++ b/packages/core/src/__tests__/snapshots-mutation.test.ts
@@ -21,7 +21,7 @@ describe('snapshots.ts mutation coverage', () => {
     });
 
     it('treats NaN seconds as zero', () => {
-      // Disabling/flipping the finite guard on line 12 would route NaN to
+      // Disabling/flipping the finite guard in clampSeconds would route NaN to
       // Math.floor(NaN) === NaN instead of returning 0.
       const snapshot = buildSnapshot({ totalSeconds: Number.NaN });
 
@@ -32,7 +32,7 @@ describe('snapshots.ts mutation coverage', () => {
     });
 
     it('treats Infinity seconds via the finite guard, not as a large value', () => {
-      // The `||` -> `&&` mutant on line 12 would let Infinity skip the guard,
+      // The `||` -> `&&` mutant in clampSeconds would let Infinity skip the guard,
       // hit `value >= MAX_SAFE_INTEGER`, and return MAX_SAFE_INTEGER.
       const snapshot = buildSnapshot({ totalSeconds: Number.POSITIVE_INFINITY });
 
@@ -41,7 +41,7 @@ describe('snapshots.ts mutation coverage', () => {
     });
   });
 
-  describe('buildSnapshot seconds fallback chain (line 27)', () => {
+  describe('buildSnapshot seconds fallback chain', () => {
     it('uses the provided initialSeconds verbatim', () => {
       // `??` -> `&&` mutants on the fallback chain would coerce a provided
       // initialSeconds of 90 into 0 (X && 0) or into totalSeconds (X && total).
@@ -68,8 +68,8 @@ describe('snapshots.ts mutation coverage', () => {
     });
 
     it('requires BOTH zero seconds AND stopped state for isCompleted', () => {
-      // Targets line 38: `&&` -> `||`, the full condition -> `true`, and the
-      // right operand -> `true`. Each must keep these two cases false.
+      // Targets the isCompleted `&&`: `&&` -> `||`, the full condition -> `true`,
+      // and the right operand -> `true`. Each must keep these two cases false.
       const zeroButRunning = buildSnapshot({ totalSeconds: 0, state: TimerState.RUNNING });
       expect(zeroButRunning.isCompleted).toBe(false);
 
@@ -81,7 +81,7 @@ describe('snapshots.ts mutation coverage', () => {
     });
   });
 
-  describe('buildSnapshotSequence (line 58)', () => {
+  describe('buildSnapshotSequence', () => {
     it('applies the provided initialSeconds to every snapshot', () => {
       // `initialSeconds ?? safeTotal` -> `initialSeconds && safeTotal` would
       // replace the provided 100 with safeTotal (4) on every snapshot.

--- a/packages/core/src/__tests__/state-machine-mutation.test.ts
+++ b/packages/core/src/__tests__/state-machine-mutation.test.ts
@@ -7,10 +7,44 @@ import { StateMachine, TimerState } from '../state/state-machine';
  * Each test below pins an OBSERVABLE behavior (return value, getCurrentState(),
  * canX() booleans, or onStateChange invocations) tied to a surviving mutant.
  *
- * NOTE: Several survivors in this file are genuinely EQUIVALENT mutants because
- * the constructs they touch are purely defensive over provably-safe operands
- * (see suspected_equivalent in the report). The tests here lock down the real
- * behavior so any NON-equivalent regression is still caught.
+ * ---------------------------------------------------------------------------
+ * PROVEN-EQUIVALENT SURVIVORS (documented, not killed — no public-API input can
+ * distinguish the mutant from the real code). These are honest survivors.
+ *
+ * Reachability invariant used below: `currentState` starts at IDLE and is only
+ * ever reassigned to `VALID_TRANSITIONS[currentState][action]` after a truthy
+ * guard, i.e. to one of the table's VALUES — every one of which is a TimerState
+ * member. VALID_TRANSITIONS has an entry for ALL FOUR members (IDLE, RUNNING,
+ * PAUSED, STOPPED). So `VALID_TRANSITIONS[currentState]` is ALWAYS a defined
+ * object, and `currentState` is ALWAYS one of the four states.
+ *
+ * 1) destroy() guard, line 111 — the ENTIRE cluster is equivalent:
+ *      L111:9  ConditionalExpression -> `false`        (whole `if` test)
+ *      L111:9  ConditionalExpression -> `false`        (left operand `=== IDLE`)
+ *      L111:9  LogicalOperator       -> `... && ...`   (&&, always false)
+ *      L111:45 ConditionalExpression -> `false`        (right operand `=== STOPPED`)
+ *      L111:82 BlockStatement        -> `{}`           (drops the `return`)
+ *    Every one of these makes destroy() fall through to `performTransition('stop')`
+ *    for the IDLE and/or STOPPED cases that the guard used to short-circuit. But
+ *    'stop' is NOT a valid transition from IDLE ({start}) or from STOPPED ({reset}),
+ *    so performTransition returns false WITHOUT mutating state or firing
+ *    onStateChange. destroy() returns void, so its inner boolean is unobservable.
+ *    Net effect on the only public observables (getCurrentState / canX / isRunning
+ *    / onStateChange) is identical => EQUIVALENT. The guard is a redundant
+ *    early-out; performTransition already rejects the same no-ops. The tests in
+ *    "destroy() guard" below still pin the real behavior so any NON-equivalent
+ *    regression (e.g. destroy from RUNNING/PAUSED) is caught.
+ *
+ * 2) canResume / canPause, lines 127 & 128 — OptionalChaining removed:
+ *      L127:30 `VALID_TRANSITIONS[currentState]?.resume` -> `[currentState].resume`
+ *      L128:29 `VALID_TRANSITIONS[currentState]?.pause`  -> `[currentState].pause`
+ *    The `?.` only short-circuits when the left operand is null/undefined. By the
+ *    reachability invariant `VALID_TRANSITIONS[currentState]` is never undefined,
+ *    so `.resume`/`.pause` can never throw and the short-circuit is never taken:
+ *    dropping `?.` yields byte-identical behavior => EQUIVALENT. The
+ *    "capability queries across every state" tests below still pin the real
+ *    canResume/canPause values in all four states.
+ * ---------------------------------------------------------------------------
  */
 describe('StateMachine - mutation hardening', () => {
   describe('performTransition lookup (line 68 ?.[action])', () => {

--- a/packages/core/src/__tests__/time-providers-mutation.test.ts
+++ b/packages/core/src/__tests__/time-providers-mutation.test.ts
@@ -5,7 +5,9 @@ import { createSafeTimeProvider, createMonotonicTimeSource } from '../runtime/ti
  * Mutation-killing tests for src/runtime/time-providers.ts.
  *
  * These assert observable behavior through the public factory functions
- * `createSafeTimeProvider` and `createMonotonicTimeSource`.
+ * `createSafeTimeProvider` and `createMonotonicTimeSource`. Titles describe the
+ * mutation each case kills conceptually (boundary, forced-true, guard clause)
+ * rather than by volatile line number / Stryker mutant id, which drift every run.
  */
 
 /** Install a stubbed global `performance.now` that yields `vals` in order (last value repeats). */
@@ -26,8 +28,8 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe('createSafeTimeProvider - initialization validation (lines 42-43)', () => {
-  it('keeps the performance provider when init reading is exactly 0 (>= boundary, mutant 298)', () => {
+describe('createSafeTimeProvider - initialization validation', () => {
+  it('keeps the performance provider when init reading is exactly 0 (>= boundary)', () => {
     // 0 satisfies testTime >= 0; a `> 0` mutant would reject it and fall back to date.
     stubPerf(0);
     const p = createSafeTimeProvider();
@@ -35,7 +37,7 @@ describe('createSafeTimeProvider - initialization validation (lines 42-43)', () 
     expect(p.isHighResolution).toBe(true);
   });
 
-  it('falls back to date when init reading is negative (>= forced true, mutant 297)', () => {
+  it('falls back to date when init reading is negative (>= forced true)', () => {
     // -5 fails testTime >= 0, so the real code throws and falls back.
     // A mutant forcing the condition true would wrongly keep performance.
     stubPerf(-5);
@@ -44,7 +46,7 @@ describe('createSafeTimeProvider - initialization validation (lines 42-43)', () 
     expect(p.isHighResolution).toBe(false);
   });
 
-  it('keeps the performance provider when init reading equals MAX_SAFE_INTEGER (<= boundary, mutant 301)', () => {
+  it('keeps the performance provider when init reading equals MAX_SAFE_INTEGER (<= boundary)', () => {
     // MAX satisfies testTime <= MAX; a `< MAX` mutant would reject it.
     stubPerf(Number.MAX_SAFE_INTEGER);
     const p = createSafeTimeProvider();
@@ -52,7 +54,7 @@ describe('createSafeTimeProvider - initialization validation (lines 42-43)', () 
     expect(p.isHighResolution).toBe(true);
   });
 
-  it('falls back to date when init reading exceeds MAX_SAFE_INTEGER (<= forced true, mutant 300)', () => {
+  it('falls back to date when init reading exceeds MAX_SAFE_INTEGER (<= forced true)', () => {
     // MAX+1 is finite but fails testTime <= MAX, so real code falls back.
     stubPerf(Number.MAX_SAFE_INTEGER + 1);
     const p = createSafeTimeProvider();
@@ -61,7 +63,7 @@ describe('createSafeTimeProvider - initialization validation (lines 42-43)', () 
   });
 });
 
-describe('createSafeTimeProvider - now() validation + fallback switch (lines 63-77)', () => {
+describe('createSafeTimeProvider - now() validation + fallback switch', () => {
   // Each test inits with a valid performance reading (so the provider starts as
   // 'performance'), then returns a bad value from now(). The real code throws,
   // permanently switches to the date fallback, and returns a valid time.
@@ -79,19 +81,19 @@ describe('createSafeTimeProvider - now() validation + fallback switch (lines 63-
     expect(result).toBeGreaterThanOrEqual(0);
   }
 
-  it('rejects NaN and falls back (whole-condition mutants 312/314 etc.)', () => {
+  it('rejects NaN and falls back (whole-condition guard)', () => {
     expectFallbackOnBadNow(NaN);
   });
 
-  it('rejects a negative reading and falls back (>= 0 mutants 313/314/322)', () => {
+  it('rejects a negative reading and falls back (>= 0 guard)', () => {
     expectFallbackOnBadNow(-5);
   });
 
-  it('rejects a numeric string and falls back (typeof mutants 315/316/318)', () => {
+  it('rejects a numeric string and falls back (non-number guard)', () => {
     expectFallbackOnBadNow('5');
   });
 
-  it('rejects Infinity and falls back (isFinite mutants)', () => {
+  it('rejects Infinity and falls back (isFinite guard)', () => {
     expectFallbackOnBadNow(Infinity);
   });
 
@@ -100,8 +102,8 @@ describe('createSafeTimeProvider - now() validation + fallback switch (lines 63-
   });
 });
 
-describe('createSafeTimeProvider - fallback (Date.now) validation (lines 81-84)', () => {
-  it('returns 0 when the Date fallback yields Infinity (mutants 339/340/341/342/343)', () => {
+describe('createSafeTimeProvider - fallback (Date.now) validation', () => {
+  it('returns 0 when the Date fallback yields Infinity', () => {
     // performance unavailable -> provider is the date fallback from the start.
     vi.stubGlobal('performance', undefined);
     vi.spyOn(Date, 'now').mockReturnValue(Infinity);
@@ -112,35 +114,70 @@ describe('createSafeTimeProvider - fallback (Date.now) validation (lines 81-84)'
     expect(p.now()).toBe(0);
   });
 
-  it('returns 0 when the Date fallback yields a negative value (mutant 339)', () => {
+  it('returns 0 when the Date fallback yields a negative value', () => {
     vi.stubGlobal('performance', undefined);
     vi.spyOn(Date, 'now').mockReturnValue(-5);
     const p = createSafeTimeProvider();
     expect(p.now()).toBe(0);
   });
+
+  it('returns 0 when the Date fallback exceeds MAX_SAFE_INTEGER (shared upper-bound guard)', () => {
+    // A finite Date reading above the safe-integer ceiling must be rejected on the fallback
+    // path too, exactly as the primary now() path rejects it. Guards the unified isValidTime
+    // upper bound: a `< MAX` -> `<= MAX` or dropped-bound mutant would return the oversized value.
+    vi.stubGlobal('performance', undefined);
+    vi.spyOn(Date, 'now').mockReturnValue(Number.MAX_SAFE_INTEGER + 1);
+    const p = createSafeTimeProvider();
+    expect(p.type).toBe('date');
+    expect(p.now()).toBe(0);
+  });
 });
 
-describe('createMonotonicTimeSource - startValue sanitization (line 117)', () => {
+/**
+ * ── EQUIVALENT surviving mutants in createMonotonicTimeSource (documented, deliberately NOT tested) ──
+ * These three Stryker survivors are observationally identical to the original for every numeric time
+ * reading; the ONLY input that distinguishes each is a negative-zero SIGN, visible solely via
+ * Object.is / (1/x), which is outside the time-value contract — all downstream elapsed math and
+ * monotonicity treat -0 === 0 (`-0 < x` ≡ `0 < x`, and `x - (-0) === x - 0`). Production, moreover,
+ * only ever calls createMonotonicTimeSource(source) with the default startValue = 0
+ * (see countdown-engine.ts), so none of these boundaries is reachable with a distinguishing value.
+ *
+ *   • L116 EqualityOperator  `startValue >= 0` -> `startValue > 0`
+ *     Differs only at startValue === 0: `0 >= 0` keeps startValue (= 0); `0 > 0` falls to the `: 0`
+ *     default (also 0). Both set last = 0 — same first reading. (At -0 the real code keeps last = -0
+ *     vs the mutant's 0; Object.is-only, never observed by time arithmetic.)
+ *   • L120 first operand ConditionalExpression -> false  (`typeof next !== 'number'` -> `false`)
+ *     A redundant defensive clause: Number.isFinite(x) is false for EVERY non-number (it never
+ *     coerces), so the next operand `!Number.isFinite(next)` already covers every non-number the
+ *     typeof clause caught. Whenever the dropped operand was true, the following operand is also
+ *     true, so the same early-return branch is taken.
+ *   • L120 EqualityOperator  `next < last` -> `next <= last`
+ *     Differs only at next === last: the original re-assigns last = next and returns it; the mutant
+ *     returns the unchanged last. For finite numbers next === last means equal values, so the
+ *     returned number and all subsequent comparisons are identical. (Again -0-vs-0 is the sole
+ *     Object.is-only exception.)
+ */
+describe('createMonotonicTimeSource - startValue sanitization', () => {
   // The init `last` value is exposed by calling the wrapper with a source that
   // returns NaN: the wrapper then returns `last` unchanged.
   const badSource = () => NaN;
 
-  it('keeps a valid non-negative startValue (mutants 355/360/361 force it to 0)', () => {
+  it('keeps a valid non-negative startValue (a forced-to-0 mutant would fail this)', () => {
     const fn = createMonotonicTimeSource(badSource, 5);
     expect(fn()).toBe(5);
   });
 
-  it('resets a NaN startValue to 0 (whole condition forced true, mutant 354)', () => {
+  it('resets a NaN startValue to 0 (whole condition forced true)', () => {
     const fn = createMonotonicTimeSource(badSource, NaN);
     expect(fn()).toBe(0);
   });
 
-  it('resets an Infinity startValue to 0 (isFinite mutants 357/358)', () => {
+  it('resets an Infinity startValue to 0 (isFinite guard)', () => {
     const fn = createMonotonicTimeSource(badSource, Infinity);
     expect(fn()).toBe(0);
   });
 
-  it('resets a negative startValue to 0 (>= 0 mutants 356/362/364)', () => {
+  it('resets a negative startValue to 0 (>= 0 guard)', () => {
     const fn = createMonotonicTimeSource(badSource, -5);
     expect(fn()).toBe(0);
   });
@@ -151,8 +188,8 @@ describe('createMonotonicTimeSource - startValue sanitization (line 117)', () =>
   });
 });
 
-describe('createMonotonicTimeSource - reading validation & monotonicity (line 121)', () => {
-  it('repairs NaN/invalid readings to the last good value (mutants 369/370/371)', () => {
+describe('createMonotonicTimeSource - reading validation & monotonicity', () => {
+  it('repairs NaN/invalid readings to the last good value', () => {
     // A valid first reading, then NaN. The wrapper must repair NaN to the prior good value.
     const vals: unknown[] = [42, NaN];
     let i = 0;
@@ -186,5 +223,30 @@ describe('createMonotonicTimeSource - reading validation & monotonicity (line 12
     expect(fn()).toBe(5);
     expect(fn()).toBe(5);
     expect(fn()).toBe(8);
+  });
+});
+
+describe('createMonotonicTimeSource - a throwing source propagates (documented "not caught" contract)', () => {
+  // The wrapper repairs out-of-range *values* (NaN/Infinity/backward) to the last good reading,
+  // but a source that *throws* is intentionally NOT caught (see the doc comment on the factory):
+  // the exception must propagate so the caller's error handling (Timer's onError) can react.
+  // This is the deliberate contrast with createSafeTimeProvider, whose now() swallows and falls back.
+  it('re-throws a source exception instead of swallowing it', () => {
+    const fn = createMonotonicTimeSource(() => {
+      throw new Error('source failure');
+    });
+    expect(() => fn()).toThrow('source failure');
+  });
+
+  it('does not repair a throw to the last good value (the throw path is distinct from value repair)', () => {
+    let call = 0;
+    const fn = createMonotonicTimeSource(() => {
+      call += 1;
+      if (call === 1) return 42;
+      throw new Error('later failure');
+    });
+    expect(fn()).toBe(42); // first reading is a valid, good value
+    // A throw on a later call is NOT quietly repaired to the retained 42 — it surfaces.
+    expect(() => fn()).toThrow('later failure');
   });
 });

--- a/packages/core/src/__tests__/time-providers-property.test.ts
+++ b/packages/core/src/__tests__/time-providers-property.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import fc from 'fast-check';
+import { createSafeTimeProvider } from '../runtime/time-providers';
+
+/**
+ * Trust-boundary suite for src/runtime/time-providers.ts `isValidTime`.
+ *
+ * createSafeTimeProvider validates every reading coming from the GLOBAL
+ * performance.now() / Date.now() — an UNTRUSTED input boundary the tests stub via
+ * vi.stubGlobal / vi.spyOn. `isValidTime` is the sole guard that rejects hostile
+ * readings, and its correctness hinges on `Number.isFinite`'s NO-coercion semantics
+ * (see the code comment: the global `isFinite` would coerce '5'/''/null/[]/true into
+ * finite numbers). Stryker has NO mutator that swaps `Number.isFinite` for the global
+ * `isFinite`, so mutation score stays 100% while such a regression would silently LEAK
+ * coerced clock values into downstream elapsed-time math. These tests pin that contract
+ * at ALL THREE call sites (init probe, now(), Date.now fallback) — the partitions the
+ * existing mutation suite leaves open (it only exercises the coercion family via a single
+ * '5' at the now() site).
+ *
+ * ── EQUIVALENT surviving mutants in this file (documented, deliberately NOT tested) ──
+ * The following Stryker survivors are genuinely UNOBSERVABLE through the public surface,
+ * so no oracle can kill them — they are equivalent mutants, not coverage gaps:
+ *   • L60 StringLiteral `throw new Error('performance.now() not available or invalid')` -> ""
+ *     Thrown inside initializeProvider's try and immediately swallowed by the bare `catch`
+ *     that sets currentProvider = fallbackProvider. The message is never read; only the
+ *     (message-independent) fallback assignment is observable.
+ *   • L76 StringLiteral `throw new Error('Invalid time value returned')` -> ""
+ *     Thrown inside now()'s try and swallowed by the local `catch` that runs the fallback
+ *     path; the message text never surfaces through now()/type/isHighResolution.
+ *   • L79 ConditionalExpression `if (currentProvider !== fallbackProvider)` -> true
+ *     Forcing it true only self-reassigns currentProvider = fallbackProvider when it is
+ *     ALREADY fallbackProvider (a same-reference no-op); resulting state is identical.
+ * (Out of scope, pre-existing debt — createMonotonicTimeSource L120's `typeof` redundancy
+ * and `next < last` vs `<=` off-by-one — are unrelated to this change and not addressed here.)
+ */
+
+/** Install a stubbed global `performance.now` that yields `vals` in order (last value repeats). */
+function stubPerf(...vals: unknown[]): void {
+  const fn = vi.fn();
+  vals.forEach((v, i) => {
+    if (i === vals.length - 1) {
+      fn.mockReturnValue(v as number);
+    } else {
+      fn.mockReturnValueOnce(v as number);
+    }
+  });
+  vi.stubGlobal('performance', { now: fn });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+/**
+ * Families that `Number.isFinite` rejects but the GLOBAL `isFinite` would coerce-and-accept:
+ * Number('') === 0, Number('  ') === 0, Number([]) === 0, Number(null) === 0,
+ * Number(true) === 1, Number(false) === 0, Number('5') === 5, Number([5]) === 5.
+ * A `Number.isFinite` -> global `isFinite` regression would accept every one of these and
+ * leak the coerced value; each case below is red under that regression.
+ */
+const COERCION_TRAPS: [string, unknown][] = [
+  ['numeric string', '5'],
+  ['empty string', ''],
+  ['whitespace string', '  '],
+  ['null', null],
+  ['empty array', []],
+  ['single-element array', [5]],
+  ['boolean true', true],
+  ['boolean false', false],
+];
+
+describe('isValidTime trust boundary — INIT probe rejects coercion traps', () => {
+  for (const [name, bad] of COERCION_TRAPS) {
+    it(`falls back to the date provider when performance.now() yields ${name} at init`, () => {
+      stubPerf(bad);
+      const p = createSafeTimeProvider();
+      // A global-isFinite regression would coerce-accept the reading and keep 'performance'.
+      expect(p.type).toBe('date');
+      expect(p.isHighResolution).toBe(false);
+    });
+  }
+});
+
+describe('isValidTime trust boundary — Date.now fallback never leaks coercion traps', () => {
+  for (const [name, bad] of COERCION_TRAPS) {
+    it(`returns the safe 0 when Date.now() yields ${name}`, () => {
+      vi.stubGlobal('performance', undefined); // no performance -> init picks the date fallback
+      vi.spyOn(Date, 'now').mockReturnValue(bad as number);
+      const p = createSafeTimeProvider();
+      expect(p.type).toBe('date');
+      const r = p.now();
+      // A global-isFinite regression would return the coerced/raw value instead of 0.
+      expect(r).toBe(0);
+      expect(typeof r).toBe('number');
+      expect(Number.isFinite(r)).toBe(true);
+    });
+  }
+});
+
+describe('isValidTime trust boundary — now() falls back on every coercion trap, never leaks', () => {
+  for (const [name, bad] of COERCION_TRAPS) {
+    it(`falls back and never returns ${name} from now()`, () => {
+      stubPerf(1000, bad); // valid init reading, then a hostile reading from now()
+      const p = createSafeTimeProvider();
+      expect(p.type).toBe('performance'); // chosen at init
+      const r = p.now();
+      expect(p.type).toBe('date'); // permanent switch after the bad reading
+      expect(typeof r).toBe('number');
+      expect(Number.isFinite(r)).toBe(true);
+      expect(r).toBeGreaterThanOrEqual(0);
+      expect(r).not.toBe(bad); // never leak the raw hostile value
+    });
+  }
+});
+
+describe('createSafeTimeProvider — totality of now() (property)', () => {
+  // Universal law: for ANY behavior of the untrusted global clocks — including NaN,
+  // ±Infinity, negatives, out-of-range, non-numbers and coercion traps in any order —
+  // now() must be TOTAL: always a finite number in [0, MAX_SAFE_INTEGER], never throwing.
+  const hostileReading = fc.oneof(
+    fc.double(), // full double range incl. NaN and ±Infinity (fast-check defaults)
+    fc.integer(),
+    fc.constantFrom(
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+      0,
+      -0,
+      -1,
+      Number.MAX_SAFE_INTEGER,
+      Number.MAX_SAFE_INTEGER + 1,
+      1e308,
+      -1e308
+    ),
+    fc.string(),
+    fc.constantFrom(null, undefined, true, false, '5', '')
+  );
+
+  // Build a vi.fn that yields `vals` in order, then repeats the last value forever.
+  const seq = (vals: unknown[]) => {
+    const fn = vi.fn();
+    vals.forEach((v, i) =>
+      i === vals.length - 1 ? fn.mockReturnValue(v as number) : fn.mockReturnValueOnce(v as number)
+    );
+    return fn;
+  };
+
+  it('now() is always a finite number in [0, MAX_SAFE_INTEGER] and never throws, for ANY clock behavior', () => {
+    fc.assert(
+      fc.property(
+        fc.array(hostileReading, { minLength: 1, maxLength: 6 }),
+        fc.array(hostileReading, { minLength: 1, maxLength: 6 }),
+        (perfVals, dateVals) => {
+          vi.stubGlobal('performance', { now: seq(perfVals) });
+          const dateSpy = vi.spyOn(Date, 'now').mockImplementation(seq(dateVals) as unknown as () => number);
+          try {
+            const provider = createSafeTimeProvider();
+            for (let i = 0; i < 8; i += 1) {
+              const r = provider.now(); // must NOT throw
+              expect(typeof r).toBe('number');
+              expect(Number.isNaN(r)).toBe(false);
+              expect(Number.isFinite(r)).toBe(true);
+              expect(r).toBeGreaterThanOrEqual(0);
+              expect(r).toBeLessThanOrEqual(Number.MAX_SAFE_INTEGER);
+            }
+          } finally {
+            // Restore inside the run so fast-check's own inter-run Date.now stays sane.
+            dateSpy.mockRestore();
+            vi.unstubAllGlobals();
+          }
+        }
+      ),
+      { numRuns: 1000 }
+    );
+  });
+});

--- a/packages/core/src/__tests__/timer-mutation.test.ts
+++ b/packages/core/src/__tests__/timer-mutation.test.ts
@@ -105,9 +105,61 @@ describe('Timer - mutation coverage', () => {
     expect(timer.getTotalSeconds()).toBe(8);
   });
 
+  // Mutant 401: L118 resume guard `totalSeconds < initialValue` -> `true` (ConditionalExpression).
+  // The guard's purpose is to RESUME (back-date elapsed via pausedDuration) ONLY when the current
+  // seconds were counted DOWN below the initial value; otherwise start() must be a FRESH start
+  // measured from the restart moment. Raise the seconds ABOVE the initial value with setSeconds,
+  // capture a non-null startTimestamp with a start()/stop() that never ticks, then restart after
+  // wall-clock has advanced. Real code fresh-starts (elapsed measured from now = 3000 -> 9 left);
+  // the `true` mutant takes the resume branch, where expectedElapsed = (10 - 20) * 1000 is negative,
+  // producing a bogus pausedDuration that back-dates the clock and swallows the first second (holds
+  // at 10). (The sibling `-> <=` EqualityOperator mutant is EQUIVALENT — see the NOTE below.)
+  it('restart is a fresh start (not a resume) when current seconds exceed the initial value', () => {
+    const events = makeEvents();
+    let now = 0;
+    const timer = Timer(10, events, { timeProvider: () => now });
+
+    timer.setSeconds(20); // totalSeconds = 20 > initialValue (10); startTimestamp reset to null
+    timer.start(); // fresh start captures startTimestamp = 0
+    timer.stop(); // no tick fired: totalSeconds stays 20, startTimestamp stays non-null
+
+    now = 3000; // wall-clock advances 3s while the timer is stopped
+    timer.start(); // real: fresh start (20 is NOT < 10), measuring elapsed from now = 3000
+
+    now = 4000; // 1s after the restart
+    vi.advanceTimersByTime(100);
+
+    // Fresh start: remaining = min(10, max(0, 10 - 1)) = 9.
+    expect(timer.getTotalSeconds()).toBe(9);
+    expect(events.onTick).toHaveBeenLastCalledWith(9);
+  });
+
+  /*
+   * Equivalent mutants in timer.ts — documented, intentionally left as honest survivors:
+   *
+   * - L118:38 EqualityOperator `totalSeconds < initialValue` -> `<=` (mutant 402): the two
+   *   comparisons differ ONLY when totalSeconds === initialValue with a non-null startTimestamp
+   *   (real -> fresh start, mutant -> resume). In that exact state the resume branch computes
+   *   expectedElapsed = (initialValue - totalSeconds) * 1000 = 0, so pausedDuration becomes
+   *   now - startTimestamp, which makes every future elapsedMs (= T - startTimestamp -
+   *   pausedDuration = T - now) identical to the fresh-start branch (startTimestamp = now,
+   *   pausedDuration = 0). The invariant `lastReportedSeconds === totalSeconds` holds whenever
+   *   startTimestamp !== null, so the first onTick fires at the same threshold too. Observationally
+   *   identical -> unkillable. (Note the `-> true` sibling IS killable: it ALSO flips the
+   *   totalSeconds > initialValue case, where expectedElapsed goes negative — see the test above.)
+   *
+   * - L138:9 stop() `if (intervalId)` -> `if (true)` (mutant 414): the branch only differs when
+   *   intervalId is null (setInterval never returns a falsy id). Then the mutant runs
+   *   clearInterval(null) — a spec no-op — and re-assigns intervalId = null (already null). No
+   *   public observable changes (isRunning() stays false) -> unkillable.
+   */
+
   // Mutants 479 (`||` -> `&&`) and 480 (whole `if` -> false) in setSeconds.
   // NaN is `typeof 'number'` but not finite; the real guard returns early and leaves
   // totalSeconds untouched. Both mutants let NaN through, corrupting totalSeconds to NaN.
+  // (Equivalent, documented: the first-operand-only mutant `typeof seconds !== 'number'` -> false
+  //  is unobservable — `!Number.isFinite(seconds)` already rejects every non-number without
+  //  coercion, so the same early return fires; the typeof clause is redundant defense-in-depth.)
   it('setSeconds ignores NaN and leaves totalSeconds untouched', () => {
     const events = makeEvents();
     const timer = Timer(10, events);
@@ -119,6 +171,8 @@ describe('Timer - mutation coverage', () => {
 
   // Mutant 492: setInitialValue finite-number guard `if (...)` -> false.
   // The mutant lets NaN through, corrupting initialValue to NaN.
+  // (Equivalent, documented: the first-operand-only mutant `typeof seconds !== 'number'` -> false
+  //  is unobservable — `!Number.isFinite(seconds)` subsumes it, so any non-number still returns early.)
   it('setInitialValue ignores NaN and leaves initialValue untouched', () => {
     const events = makeEvents();
     const timer = Timer(10, events);

--- a/packages/core/src/api/countdown-engine.ts
+++ b/packages/core/src/api/countdown-engine.ts
@@ -3,17 +3,9 @@ import { createSafeTimeProvider, createMonotonicTimeSource, type TimeProvider } 
 import { StateMachine, TimerState } from '../state/state-machine';
 import { decompose, type CountdownParts } from '../time/decompose';
 import { clampSeconds } from '../time/clamp';
+import type { CountdownSnapshot } from '../model/countdown-snapshot';
 
 export type { CountdownParts };
-
-export interface CountdownSnapshot {
-  initialSeconds: number;
-  totalSeconds: number;
-  parts: CountdownParts;
-  state: TimerState;
-  isRunning: boolean;
-  isCompleted: boolean;
-}
 
 export interface CountdownSubscription {
   unsubscribe: () => void;

--- a/packages/core/src/api/countdown.ts
+++ b/packages/core/src/api/countdown.ts
@@ -1,4 +1,5 @@
-import { CountdownEngine, type CountdownSnapshot } from './countdown-engine';
+import { CountdownEngine } from './countdown-engine';
+import type { CountdownSnapshot } from '../model/countdown-snapshot';
 import { TimerState } from '../state/state-machine';
 import { Formatter } from '../format/formatter';
 
@@ -122,4 +123,3 @@ export function Countdown(initialSeconds: number, options: CountdownOptions = {}
 }
 
 export { TimerState };
-export type { CountdownSnapshot };

--- a/packages/core/src/format/formatter.ts
+++ b/packages/core/src/format/formatter.ts
@@ -1,4 +1,4 @@
-import type { CountdownSnapshot } from '../api/countdown-engine';
+import type { CountdownSnapshot } from '../model/countdown-snapshot';
 import { decompose } from '../time/decompose';
 import { clampSeconds } from '../time/clamp';
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,9 +6,10 @@ export {
   buildSnapshot,
   type CountdownEngineInstance,
   type CountdownEngineOptions,
-  type CountdownSnapshot,
   type CountdownParts,
 } from './api/countdown-engine'
+
+export type { CountdownSnapshot } from './model/countdown-snapshot'
 
 export { TimerState } from './state/state-machine'
 

--- a/packages/core/src/model/countdown-snapshot.ts
+++ b/packages/core/src/model/countdown-snapshot.ts
@@ -1,0 +1,11 @@
+import type { TimerState } from '../state/state-machine';
+import type { CountdownParts } from '../time/decompose';
+
+export interface CountdownSnapshot {
+  initialSeconds: number;
+  totalSeconds: number;
+  parts: CountdownParts;
+  state: TimerState;
+  isRunning: boolean;
+  isCompleted: boolean;
+}

--- a/packages/core/src/runtime/time-providers.ts
+++ b/packages/core/src/runtime/time-providers.ts
@@ -25,6 +25,22 @@ function createDateTimeProvider(): TimeProvider {
   };
 }
 
+/**
+ * True only for a usable absolute clock reading: a finite, non-negative number within the
+ * safe-integer range [0, Number.MAX_SAFE_INTEGER]. Readings feed elapsed-time subtraction and
+ * Math.floor(delta / 1000) downstream; past Number.MAX_SAFE_INTEGER (2^53 - 1) millisecond
+ * deltas are no longer exactly representable, so an out-of-range reading would corrupt the
+ * second count. This is the single source of truth for that contract across createSafeTimeProvider.
+ *
+ * Number.isFinite performs no coercion (unlike the global isFinite) and returns false for every
+ * non-number, NaN and +/-Infinity, so it alone subsumes the former `typeof === 'number'` and
+ * `!isNaN(...)` clauses. It must stay first so a runtime non-number short-circuits before the
+ * relational comparisons, which would otherwise coerce their operands (e.g. '5' >= 0 === true).
+ */
+function isValidTime(value: number): boolean {
+  return Number.isFinite(value) && value >= 0 && value <= Number.MAX_SAFE_INTEGER;
+}
+
 export function createSafeTimeProvider(): TimeProvider {
   let currentProvider: TimeProvider;
   const fallbackProvider = createDateTimeProvider();
@@ -35,13 +51,7 @@ export function createSafeTimeProvider(): TimeProvider {
       // Test if performance.now() is available and working
       if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
         const testTime = performance.now();
-        if (
-          typeof testTime === 'number' &&
-          Number.isFinite(testTime) &&
-          !isNaN(testTime) &&
-          testTime >= 0 &&
-          testTime <= Number.MAX_SAFE_INTEGER
-        ) {
+        if (isValidTime(testTime)) {
           currentProvider = createPerformanceTimeProvider();
           return;
         }
@@ -60,13 +70,7 @@ export function createSafeTimeProvider(): TimeProvider {
     now: () => {
       try {
         const time = currentProvider.now();
-        if (
-          typeof time === 'number' &&
-          Number.isFinite(time) &&
-          !isNaN(time) &&
-          time >= 0 &&
-          time <= Number.MAX_SAFE_INTEGER
-        ) {
+        if (isValidTime(time)) {
           return time;
         }
         throw new Error('Invalid time value returned');
@@ -77,12 +81,7 @@ export function createSafeTimeProvider(): TimeProvider {
         }
         try {
           const fallbackTime = fallbackProvider.now();
-          if (
-            typeof fallbackTime === 'number' &&
-            Number.isFinite(fallbackTime) &&
-            !isNaN(fallbackTime) &&
-            fallbackTime >= 0
-          ) {
+          if (isValidTime(fallbackTime)) {
             return fallbackTime;
           }
         } catch {

--- a/packages/core/testing-utils/assertions.ts
+++ b/packages/core/testing-utils/assertions.ts
@@ -1,4 +1,4 @@
-import type { CountdownSnapshot } from '../src/api/countdown-engine';
+import type { CountdownSnapshot } from '../src/model/countdown-snapshot';
 import { TimerState } from '../src/state/state-machine';
 
 const formatErrorMessage = (message: string, details?: string) => {

--- a/packages/core/testing-utils/snapshots.ts
+++ b/packages/core/testing-utils/snapshots.ts
@@ -1,5 +1,5 @@
-import type { CountdownSnapshot } from '../src/api/countdown-engine';
-import { decompose } from '../src/time/decompose';
+import { buildSnapshot as buildEngineSnapshot } from '../src/api/countdown-engine';
+import type { CountdownSnapshot } from '../src/model/countdown-snapshot';
 import { clampSeconds } from '../src/time/clamp';
 import { TimerState } from '../src/state/state-machine';
 
@@ -10,19 +10,18 @@ export interface SnapshotOptions {
 }
 
 export function buildSnapshot(options: SnapshotOptions = {}): CountdownSnapshot {
-  const initialSeconds = clampSeconds(options.initialSeconds ?? options.totalSeconds ?? 0);
-  const totalSeconds = clampSeconds(options.totalSeconds ?? options.initialSeconds ?? 0);
-  const state = options.state ?? (totalSeconds > 0 ? TimerState.IDLE : TimerState.STOPPED);
-  // Canonical, lossless breakdown — same source of truth as the engine and formatters.
-  const parts = decompose(totalSeconds);
-  return {
-    initialSeconds,
-    totalSeconds,
-    parts,
-    state,
-    isRunning: state === TimerState.RUNNING,
-    isCompleted: totalSeconds === 0 && state === TimerState.STOPPED,
-  };
+  // This helper owns ONLY the ergonomic option-bag defaults (the cross-fallback
+  // chains and the default-state heuristic). Every snapshot invariant — the clamp
+  // of the stored second-fields, decompose -> parts, and the isRunning/isCompleted
+  // flags — is derived by the engine's canonical buildSnapshot, which is the single
+  // source of truth. Delegating here (instead of re-implementing those rules) makes
+  // it impossible for the test double to drift from production.
+  const initialSeconds = options.initialSeconds ?? options.totalSeconds ?? 0;
+  const totalSeconds = options.totalSeconds ?? options.initialSeconds ?? 0;
+  // The default-state heuristic gates on the CLAMPED total (clampSeconds is itself the
+  // shared single source of truth for clamping); the engine re-clamps idempotently.
+  const state = options.state ?? (clampSeconds(totalSeconds) > 0 ? TimerState.IDLE : TimerState.STOPPED);
+  return buildEngineSnapshot(initialSeconds, totalSeconds, state);
 }
 
 export interface SequenceOptions extends SnapshotOptions {

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-07-11
+
+### Changed
+
+- Lockstep release with `@timekeeper-countdown/core` 0.3.2 (internal refactor only — no changes to the `useCountdown` hook). Bumps the `@timekeeper-countdown/core` dependency to `^0.3.2`.
+
 ## [0.3.1] - 2026-06-27
 
 ### Fixed

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@timekeeper-countdown/react",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "React adapter for the Timekeeper Countdown engine",
   "author": "Eduardo Kohn",
   "license": "MIT",
@@ -45,7 +45,7 @@
     "react": ">=17.0.0"
   },
   "dependencies": {
-    "@timekeeper-countdown/core": "^0.3.1"
+    "@timekeeper-countdown/core": "^0.3.2"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",


### PR DESCRIPTION
## Description

Structural, **internal-only** refactor of `@timekeeper-countdown/core`, plus the lockstep **v0.3.2** patch release of both packages. No public API or behavior change — this is a `PATCH` (verified by a release-readiness audit: the moved type stays barrel-exported with an identical shape, and the only touched behavior is an unreachable, non-exported internal guard).

- **Decouple the snapshot type from the engine** — move the `CountdownSnapshot` interface out of `api/countdown-engine.ts` into a dedicated leaf module `src/model/countdown-snapshot.ts`, removing the `format/ → api/` layer inversion. It is still re-exported from the package root barrel with a byte-identical six-field shape, so consumers importing it from `@timekeeper-countdown/core` are unaffected.
- **Consolidate the time-validity guard** — collapse the three repeated guards in `runtime/time-providers.ts` into one module-private `isValidTime()`, restoring the `MAX_SAFE_INTEGER` upper bound the fallback path had dropped. Internal only (`createSafeTimeProvider` is not exported) and unreachable for a real `Date.now()`.
- **Single source of truth for the snapshot test double** — the published `testing-utils` `buildSnapshot` now delegates to the engine's canonical `buildSnapshot`, so it can no longer drift from production (same `parts` / `isRunning` / `isCompleted` rules). Signature and output unchanged.
- **Tests** — add property and contract suites (time-provider coercion boundaries; snapshot-double vs. engine equivalence) and expand the per-unit mutation suites. Core: 453 tests.
- **Docs** — document the new `src/model` and `src/time/clamp` modules in `CLAUDE.md`; clarify in `CONTRIBUTING` that the Node 22 prerequisite is the build/dev toolchain, while the published packages support Node ≥ 18 at runtime.

## Type of Change

- [x] Refactoring (no functional changes)
- [x] Chore (dependencies, CI, build, etc.) — lockstep `v0.3.2` version bump

## How to Test

1. `npm install`
2. `bin/quality-gate.sh` — full gate (build + format:check + lint + typecheck + test) is green: core **453** tests, react **18**.
3. Confirm the public type still resolves from the barrel: `import type { CountdownSnapshot } from '@timekeeper-countdown/core'` (type-only, unchanged shape).

## Checklist

- [x] My code follows the project's code style
- [x] I have added/updated tests for my changes
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes
- [x] I have followed the [commit convention](.github/commit-convention.md)
- [x] I have updated the CHANGELOG (`packages/*/CHANGELOG.md`) — recorded as an internal-only note for the `0.3.2` release (not a user-facing change), and mirrored in `docs/changelog.md`
- [x] I have updated documentation if needed (`CLAUDE.md`, `CONTRIBUTING.md`)
